### PR TITLE
Body spherical self-collision avoidance barrier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 - Control Barrier Functions, namely: (thanks to @domrachev03 and @simeon-ned)
   - Abstract Barrier ``Barrier``
   - Frame Position Barrier ``PositionBarrier``
-- Examples for `UR5` manipulator and `go2` quadruped robot, which illustrate barriers effect.
+  - Body Spherical Barrier ``BodySphericalBarrier``
+- Examples for `UR5` manipulator and `go2` quadruped robot, and `yumi` two-armed manipulator which illustrate barriers effect.
 
 ### Changed
 

--- a/examples/barriers/README.md
+++ b/examples/barriers/README.md
@@ -44,7 +44,7 @@ https://github.com/domrachev03/pink/assets/28687492/78281f44-3676-4d4d-9619-768b
 
 
 ## Yumi self-collision avoidance
-Yumi two-armed manimpulator with constraint on minimal distance betwee frames, defined by end-effectors
+Yumi two-armed manimpulator with constraint on minimal distance between frames, defined by end-effectors
 
 
 

--- a/examples/barriers/README.md
+++ b/examples/barriers/README.md
@@ -28,8 +28,8 @@ https://github.com/domrachev03/pink/assets/28687492/f30ba7a1-98a3-44cb-ab52-23f9
 
 Go2 quadruped squating with base position is constrained by z and y coordinates:
 
-https://github.com/domrachev03/pink/assets/26837717/701bdfbe-0dba-4f9d-80e2-c018475f38d6
 
+https://github.com/domrachev03/pink/assets/28687492/78281f44-3676-4d4d-9619-768b951a15a2
 
 
 | Task | Cost |
@@ -43,6 +43,20 @@ https://github.com/domrachev03/pink/assets/26837717/701bdfbe-0dba-4f9d-80e2-c018
 | End-effector | $10^{2}$ |
 
 
+## Yumi self-collision avoidance
+Yumi two-armed manimpulator with constraint on minimal distance betwee frames, defined by end-effectors
 
 
 
+https://github.com/domrachev03/pink/assets/28687492/f8c4bc8d-63e3-4bf7-a34f-e7ede43c0438
+
+
+
+| Task | Cost |
+|------|------|
+| End-effector | (50,10) |
+| Posture | $10^{-3}$ |
+
+| Barrier | Gain |
+|------|------|
+| Body Spherical | $10^{2}$ |

--- a/examples/barriers/yumi_self_collision.py
+++ b/examples/barriers/yumi_self_collision.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Stéphane Caron
+
+"""Yumi two-armed manipulator with definition of custom frame and 
+collision avoidance w.r.t. those frames."""
+
+import meshcat_shapes
+import numpy as np
+import pinocchio as pin
+import qpsolvers
+from loop_rate_limiters import RateLimiter
+
+import pink
+from pink import solve_ik
+from pink.barriers import BodySphericalBarrier
+from pink.tasks import FrameTask, PostureTask
+from pink.visualization import start_meshcat_visualizer
+
+try:
+    from robot_descriptions.loaders.pinocchio import load_robot_description
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples need robot_descriptions, "
+        "try ``pip install robot_descriptions``"
+    ) from exc  # noqa: E501
+
+
+if __name__ == "__main__":
+    # Load the robot and define the custom frames
+    robot = load_robot_description("yumi_description", root_joint=None)
+
+    # Left arm frame
+    l_frame_placement = pin.SE3()
+    l_frame_placement.translation = np.array([0.0, 0.0, 0.05])
+    l_frame_placement.rotation = np.eye(3)
+
+    l_frame = pin.Frame(
+        "yumi_barrier_l",
+        robot.model.getJointId("yumi_joint_6_l"),
+        robot.model.getFrameId("yumi_link_7_l"),
+        l_frame_placement,
+        pin.FrameType.OP_FRAME,
+    )
+
+    robot.model.addFrame(l_frame)
+
+    # Right arm frame
+    r_frame_placement = pin.SE3()
+    r_frame_placement.translation = np.array([0.0, 0.0, 0.05])
+    r_frame_placement.rotation = np.eye(3)
+
+    r_frame = pin.Frame(
+        "yumi_barrier_r",
+        robot.model.getJointId("yumi_joint_6_r"),
+        robot.model.getFrameId("yumi_link_7_r"),
+        r_frame_placement,
+        pin.FrameType.OP_FRAME,
+    )
+
+    robot.model.addFrame(r_frame)
+    # Redefining robot data to take into account the new frames
+    robot.data = pin.Data(robot.model)
+
+    viz = start_meshcat_visualizer(robot)
+
+    # Pink tasks
+    left_end_effector_task = FrameTask(
+        "yumi_link_7_l",
+        position_cost=50.0,  # [cost] / [m]
+        orientation_cost=10.0,  # [cost] / [rad]
+    )
+    right_end_effector_task = FrameTask(
+        "yumi_link_7_r",
+        position_cost=50.0,  # [cost] / [m]
+        orientation_cost=10.0,  # [cost] / [rad]
+    )
+
+    # Pink barriers
+    ee_barrier = BodySphericalBarrier(
+        ("yumi_barrier_l", "yumi_barrier_r"),
+        d_min=0.25,
+        gain=100.0,
+        safe_displacement_gain=1.0,
+    )
+
+    posture_task = PostureTask(
+        cost=1e-3,  # [cost] / [rad]
+    )
+
+    cbf_list = [ee_barrier]
+    tasks = [left_end_effector_task, right_end_effector_task, posture_task]
+
+    q_ref = np.array(
+        [
+            0.045,
+            -0.155,
+            -0.394,
+            -0.617,
+            -0.939,
+            -0.343,
+            -1.216,
+            0,
+            0,
+            -0.374,
+            -0.249,
+            0.562,
+            -0.520,
+            0.934,
+            -0.337,
+            1.400,
+            0,
+            0,
+        ]
+    )
+    configuration = pink.Configuration(robot.model, robot.data, q_ref)
+    for task in tasks:
+        task.set_target_from_configuration(configuration)
+    viz.display(configuration.q)
+
+    viewer = viz.viewer
+    meshcat_shapes.frame(viewer["left_end_effector"], opacity=1.0)
+    meshcat_shapes.sphere(
+        viewer["left_ee_barrier"],
+        opacity=0.4,
+        color=0xFF0000,
+        radius=0.125,
+    )
+    meshcat_shapes.sphere(
+        viewer["right_ee_barrier"],
+        opacity=0.4,
+        color=0x00FF00,
+        radius=0.125,
+    )
+    meshcat_shapes.frame(viewer["right_end_effector"], opacity=1.0)
+    meshcat_shapes.frame(viewer["left_end_effector_target"], opacity=1.0)
+    meshcat_shapes.frame(viewer["right_end_effector_target"], opacity=1.0)
+
+    # Select QP solver
+    solver = qpsolvers.available_solvers[0]
+    if "osqp" in qpsolvers.available_solvers:
+        solver = "osqp"
+
+    rate = RateLimiter(frequency=200.0)
+    dt = rate.period
+    t = 0.0  # [s]
+    l_y_des = np.array([0.392, 0.392, 0.6])
+    r_y_des = np.array([0.392, 0.392, 0.6])
+    l_dy_des = np.zeros(3)
+    r_dy_des = np.zeros(3)
+
+    while True:
+        # Calculate desired trajectory
+        A = 0.1
+        B = 0.1
+        # z -- 0.4 - 0.8
+        l_y_des[:] = (
+            0.6,
+            0.1 + B * np.sin(t),
+            0.6 + A * np.sin(t),
+        )
+        r_y_des[:] = (
+            0.6,
+            -0.1 - B * np.sin(t),
+            0.6 + A * np.sin(t),
+        )
+        l_dy_des[:] = 0, B * np.cos(t), A * np.cos(t)
+        r_dy_des[:] = 0, -B * np.cos(t), A * np.cos(t)
+
+        left_end_effector_task.transform_target_to_world.translation = l_y_des
+        right_end_effector_task.transform_target_to_world.translation = r_y_des
+
+        # Update visualization frames
+        viewer["left_end_effector"].set_transform(
+            configuration.get_transform_frame_to_world(
+                left_end_effector_task.frame
+            ).np
+        )
+        viewer["right_end_effector"].set_transform(
+            configuration.get_transform_frame_to_world(
+                right_end_effector_task.frame
+            ).np
+        )
+        viewer["left_end_effector_target"].set_transform(
+            left_end_effector_task.transform_target_to_world.np
+        )
+        viewer["right_end_effector_target"].set_transform(
+            right_end_effector_task.transform_target_to_world.np
+        )
+
+        lb = configuration.get_transform_frame_to_world("yumi_barrier_l")
+        rb = configuration.get_transform_frame_to_world("yumi_barrier_r")
+
+        viewer["left_ee_barrier"].set_transform(lb.np)
+        viewer["right_ee_barrier"].set_transform(rb.np)
+
+        velocity = solve_ik(
+            configuration,
+            tasks,
+            dt,
+            solver=solver,
+            barriers=cbf_list,
+        )
+        configuration.integrate_inplace(velocity, dt)
+        dist_ee = (
+            np.linalg.norm(
+                configuration.get_transform_frame_to_world(
+                    "yumi_barrier_l"
+                ).translation
+                - configuration.get_transform_frame_to_world(
+                    "yumi_barrier_r"
+                ).translation
+            )
+            * 100
+        )
+        print(f"Distance between end effectors: {dist_ee :0.1f}cm")
+        # Visualize result at fixed FPS
+        viz.display(configuration.q)
+        rate.sleep()
+        t += dt

--- a/pink/barriers/__init__.py
+++ b/pink/barriers/__init__.py
@@ -9,9 +9,11 @@
 from .barrier import Barrier
 from .exceptions import NoPositionLimitProvided
 from .position_barrier import PositionBarrier
+from .body_spherical_barrier import BodySphericalBarrier
 
 __all__ = [
     "Barrier",
     "PositionBarrier",
     "NoPositionLimitProvided",
+    "BodySphericalBarrier",
 ]

--- a/pink/barriers/__init__.py
+++ b/pink/barriers/__init__.py
@@ -7,7 +7,7 @@
 """Control Barrier Functions."""
 
 from .barrier import Barrier
-from .exceptions import NoPositionLimitProvided
+from .exceptions import NoPositionLimitProvided, NegativeMinimumDistance
 from .position_barrier import PositionBarrier
 from .body_spherical_barrier import BodySphericalBarrier
 
@@ -15,5 +15,6 @@ __all__ = [
     "Barrier",
     "PositionBarrier",
     "NoPositionLimitProvided",
+    "NegativeMinimumDistance",
     "BodySphericalBarrier",
 ]

--- a/pink/barriers/barrier.py
+++ b/pink/barriers/barrier.py
@@ -74,7 +74,7 @@ class Barrier(abc.ABC):
         Args:
             dim: Dimension of the barrier.
             gain: barrier gain. Defaults to 1.0.
-            class_k_fn: Extended class K function.
+            gain_function: gain function.
                 Defaults to the identity function.
             safe_displacement_gain: gain for the safe backup displacement
                 cost term. Defaults to 3.0.

--- a/pink/barriers/body_spherical_barrier.py
+++ b/pink/barriers/body_spherical_barrier.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
+# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 
 """Barrier based on the distance between two frames."""
 

--- a/pink/barriers/body_spherical_barrier.py
+++ b/pink/barriers/body_spherical_barrier.py
@@ -65,7 +65,7 @@ class BodySphericalBarrier(Barrier):
         super().__init__(
             dim=1,
             gain=gain,
-            gain_function=lambda h: h / (1 + np.linalg.norm(h)),
+            gain_function=lambda h: h / (1 + np.abs(h)),
             safe_displacement_gain=safe_displacement_gain,
         )
         self.frames = frames

--- a/pink/barriers/body_spherical_barrier.py
+++ b/pink/barriers/body_spherical_barrier.py
@@ -99,7 +99,10 @@ class BodySphericalBarrier(Barrier):
         """
         pos1_world, pos2_world = self._get_frame_positions(configuration)
         return np.array(
-            [np.linalg.norm(pos1_world - pos2_world) ** 2 - self.d_min**2]
+            [
+                (pos1_world - pos2_world).dot(pos1_world - pos2_world)
+                - self.d_min**2
+            ]
         )
 
     def compute_jacobian(self, configuration: Configuration) -> np.ndarray:
@@ -136,10 +139,8 @@ class BodySphericalBarrier(Barrier):
         pos1_world, pos2_world = self._get_frame_positions(configuration)
         pos1_jac, pos2_jac = self._get_frame_jacobians(configuration)
 
-        dh_dx = 2 * np.concatenate(
-            [pos1_world - pos2_world, pos2_world - pos1_world]
-        )
-        dx_dq = np.vstack([pos1_jac, pos2_jac])
+        dh_dx = 2 * (pos1_world - pos2_world)
+        dx_dq = pos1_jac - pos2_jac
         return dh_dx.T @ dx_dq
 
     def _get_frame_positions(

--- a/pink/barriers/body_spherical_barrier.py
+++ b/pink/barriers/body_spherical_barrier.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Stéphane Caron
+
+"""Barrier based on the distance between two frames."""
+
+from typing import Tuple, Union
+
+import numpy as np
+
+from ..configuration import Configuration
+from .barrier import Barrier
+
+
+class BodySphericalBarrier(Barrier):
+    r"""A barrier based on the distance between two frames.
+
+    Defines a barrier function based on the Euclidean distance between two
+    specified frames. It allows for the specification of a minimum distance
+    threshold.
+
+    The barrier function is defined as:
+
+    .. math::
+
+        h(q) = \|p_1(q) -
+        p_2(q)\|^2 - d_{min}^2
+
+    where :math:`p_1(q)` and
+    :math:`p_2(q)` are the positions of the two
+    frames in the world coordinate system, and :math:`d_{min}`
+    is the minimum distance threshold.
+
+    Attributes:
+        frames: Tuple of two frame names.
+        d_min: Minimum distance threshold.
+    """
+
+    frames: Tuple[str, str]
+    d_min: float
+
+    def __init__(
+        self,
+        frames: Tuple[str, str],
+        d_min: float = -1,
+        gain: Union[float, np.ndarray] = 1.0,
+        safe_displacement_gain: float = 3.0,
+    ):
+        """Initialize the BodySphericalBarrier.
+
+        Args:
+            frames: Tuple of two frame names.
+            d_min: Minimum distance threshold.
+            gain: Barrier gain. Defaults to 1.0.
+            safe_displacement_gain: gain for the safe backup displacement
+                cost term. Defaults to 3.0.
+        """
+        super().__init__(
+            dim=1,
+            gain=gain,
+            gain_function=lambda h: h / (1 + np.linalg.norm(h)),
+            safe_displacement_gain=safe_displacement_gain,
+        )
+        self.frames = frames
+        self.d_min = d_min if d_min > 0 else 0.0
+
+    def compute_barrier(self, configuration: Configuration) -> np.ndarray:
+        r"""Compute the value of the barrier function.
+
+        The barrier function is computed based on the Euclidean distance
+        between the two specified frames. It considers the minimum distance
+        threshold.
+
+        The barrier function is given by:
+
+        .. math::
+
+            h(q) = \|p_1(q) -
+            p_2(q)\|^2 - d_{min}^2
+
+        where :math:`p_1(q)` and
+        :math:`p_2(q)` are the positions of the two
+        frames in the world coordinate system, and :math:`d_{min}`
+        is the minimum distance threshold.
+
+        Args:
+            configuration: Robot configuration :math:`q`.
+
+        Returns:
+            Value of the barrier function
+                :math:`h(q)`.
+        """
+        pos1_world, pos2_world = self._get_frame_positions(configuration)
+        return np.array(
+            [np.linalg.norm(pos1_world - pos2_world) ** 2 - self.d_min**2]
+        )
+
+    def compute_jacobian(self, configuration: Configuration) -> np.ndarray:
+        r"""Compute the Jacobian matrix of the barrier function.
+
+        The Jacobian matrix is computed based on the position Jacobians of the
+        two specified frames. The Jacobians are transformed to align with the
+        world coordinate system.
+
+        The Jacobian matrix is given by:
+
+        .. math::
+
+            \frac{\partial h}{\partial q}(q) =
+            2(p_1(q) -
+            p_2(q))^T \begin{bmatrix}
+                \frac{\partial p_1}{\partial q}
+                (q) \\
+                -\frac{\partial p_2}{\partial q}
+                (q)
+            \end{bmatrix}
+
+        where :math:`\frac{\partial p_1}{\partial q}(q)`
+        and :math:`\frac{\partial p_2}{\partial q}(q)`
+        are the position Jacobians of the two frames.
+
+        Args:
+            configuration: Robot configuration :math:`q`.
+
+        Returns:
+            Jacobian matrix
+                :math:`\frac{\partial h}{\partial q}(q)`.
+        """  # noqa: E501
+        pos1_world, pos2_world = self._get_frame_positions(configuration)
+        pos1_jac, pos2_jac = self._get_frame_jacobians(configuration)
+
+        dh_dx = 2 * np.concatenate(
+            [pos1_world - pos2_world, pos2_world - pos1_world]
+        )
+        dx_dq = np.vstack([pos1_jac, pos2_jac])
+        return dh_dx.T @ dx_dq
+
+    def _get_frame_positions(
+        self, configuration: Configuration
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Get the positions of the two frames in the world coordinate system.
+
+        Args:
+            configuration: Robot configuration.
+
+        Returns:
+            Tuple of position vectors of the two frames in the world
+                coordinate system.
+        """
+        pos1_world = configuration.get_transform_frame_to_world(
+            self.frames[0]
+        ).translation
+        pos2_world = configuration.get_transform_frame_to_world(
+            self.frames[1]
+        ).translation
+        return pos1_world, pos2_world
+
+    def _get_frame_jacobians(
+        self, configuration: Configuration
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Get the position Jacobians of the two frames in the world frame.
+
+        Args:
+            configuration: Robot configuration.
+
+        Returns:
+            Tuple of position Jacobian matrices of the two frames in the world
+                coordinate system.
+        """
+        pos1_jac = configuration.get_frame_jacobian(self.frames[0])[:3]
+        rotation1 = configuration.get_transform_frame_to_world(
+            self.frames[0]
+        ).rotation
+        pos1_jac = rotation1 @ pos1_jac
+
+        pos2_jac = configuration.get_frame_jacobian(self.frames[1])[:3]
+        rotation2 = configuration.get_transform_frame_to_world(
+            self.frames[1]
+        ).rotation
+        pos2_jac = rotation2 @ pos2_jac
+
+        return pos1_jac, pos2_jac

--- a/pink/barriers/body_spherical_barrier.py
+++ b/pink/barriers/body_spherical_barrier.py
@@ -12,6 +12,7 @@ import numpy as np
 
 from ..configuration import Configuration
 from .barrier import Barrier
+from .exceptions import NegativeMinimumDistance
 
 
 class BodySphericalBarrier(Barrier):
@@ -44,7 +45,7 @@ class BodySphericalBarrier(Barrier):
     def __init__(
         self,
         frames: Tuple[str, str],
-        d_min: float = -1,
+        d_min: float,
         gain: Union[float, np.ndarray] = 1.0,
         safe_displacement_gain: float = 3.0,
     ):
@@ -57,6 +58,10 @@ class BodySphericalBarrier(Barrier):
             safe_displacement_gain: gain for the safe backup displacement
                 cost term. Defaults to 3.0.
         """
+        if d_min < 0.0:
+            raise NegativeMinimumDistance(
+                "The minimum distance threshold must be non-negative."
+            )
         super().__init__(
             dim=1,
             gain=gain,
@@ -64,7 +69,7 @@ class BodySphericalBarrier(Barrier):
             safe_displacement_gain=safe_displacement_gain,
         )
         self.frames = frames
-        self.d_min = d_min if d_min > 0 else 0.0
+        self.d_min = d_min
 
     def compute_barrier(self, configuration: Configuration) -> np.ndarray:
         r"""Compute the value of the barrier function.
@@ -127,7 +132,7 @@ class BodySphericalBarrier(Barrier):
         Returns:
             Jacobian matrix
                 :math:`\frac{\partial h}{\partial q}(q)`.
-        """  # noqa: E501
+        """
         pos1_world, pos2_world = self._get_frame_positions(configuration)
         pos1_jac, pos2_jac = self._get_frame_jacobians(configuration)
 

--- a/pink/barriers/exceptions.py
+++ b/pink/barriers/exceptions.py
@@ -9,3 +9,7 @@ from ..exceptions import PinkError
 
 class NoPositionLimitProvided(PinkError):
     """If neither minimum nor maximum position limits are provided."""
+
+
+class NegativeMinimumDistance(PinkError):
+    """If the minimum distance in body spherical barrier is negative."""

--- a/tests/test_body_spherical_barrier.py
+++ b/tests/test_body_spherical_barrier.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Stéphane Caron
+
+"""Tests for position barrier limit."""
+
+import unittest
+
+import numpy as np
+from robot_descriptions.loaders.pinocchio import load_robot_description
+
+from pink import Configuration
+from pink.barriers import BodySphericalBarrier, NegativeMinimumDistance
+
+
+class TestBodySphericalBarrier(unittest.TestCase):
+    """Testing position barrier limit."""
+
+    def setUp(self):
+        """Set test fixture up."""
+        robot = load_robot_description("yumi_description")
+        model = robot.model
+        self.data = robot.data
+        self.model = model
+        self.robot = robot
+        self.ees = ("yumi_link_7_l", "yumi_link_7_r")
+        self.q0 = np.array(
+            [
+                0.045,
+                -0.155,
+                -0.394,
+                -0.617,
+                -0.939,
+                -0.343,
+                -1.216,
+                0,
+                0,
+                -0.374,
+                -0.249,
+                0.562,
+                -0.520,
+                0.934,
+                -0.337,
+                1.400,
+                0,
+                0,
+            ]
+        )
+        self.configuration = Configuration(self.model, self.data, self.q0)
+
+    def test_negative_distance(self):
+        """Raise an error when the robot body is not found."""
+        with self.assertRaises(NegativeMinimumDistance):
+            BodySphericalBarrier(self.ees, d_min=-1)
+
+    def test_dimension(self):
+        """Check dimensions of configuration limit projection."""
+        self.assertEqual(BodySphericalBarrier(self.ees, d_min=0.2).dim, 1)
+
+    def test_gains(self):
+        """Check gains of configuration limit projection."""
+        # One limit, scalar gain
+        self.assertEqual(
+            BodySphericalBarrier(self.ees, d_min=0.2).gain.shape, (1,)
+        )
+
+    def test_jacobians(self):
+        """Test that shapes of jacobians in all barriers are correct."""
+
+        barrier = BodySphericalBarrier(self.ees, d_min=0.2)
+        J = barrier.compute_jacobian(self.configuration)
+        self.assertEqual(J.ndim, 1)
+        self.assertEqual(J.shape[0], self.robot.nv)
+
+    def test_positive_when_in_safety_zone(self):
+        """Check that the barrier is positive when in the safety zone."""
+
+        barrier = BodySphericalBarrier(self.ees, d_min=0.2)
+        h = barrier.compute_barrier(self.configuration)
+        self.assertTrue(h[0] > 0)
+
+    def test_negative_when_out_of_safety_zone(self):
+        """Test that the barrier is negative when out of the safety zone."""
+
+        barrier = BodySphericalBarrier(self.ees, d_min=0.3)
+        h = barrier.compute_barrier(self.configuration)
+        self.assertTrue(h[0] < 0)

--- a/tests/test_body_spherical_barrier.py
+++ b/tests/test_body_spherical_barrier.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
+# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 
 """Tests for position barrier limit."""
 


### PR DESCRIPTION
This PR is first from the series of PRs, aimed at introduction of Control Barrier Functions, mentioned in https://github.com/stephane-caron/pink/issues/86 . This PR implements self-collision avoidance barrier, namely one of the following form:

$$h(q) = \|p_1(q) - p_2(q)\|^2 - d_{min}^2$$

where $p_{1,2}$ are positions of first and second frame of interest. It takes names of two frames of interest and minimum distance that they have to have between each other.

The functionality is demonstrated on the Yumi two-armed robot with custom frame definition w.r.t. end-effector (that is, one could define shifted frames and so make use of those constraints more practical):

https://github.com/stephane-caron/pink/assets/28687492/6cc3524c-c79e-435b-a4e9-af1e1271a148

We have some draft work on implementation of self-collision avoidance using hpp-fcl, see [here](https://github.com/domrachev03/pink/tree/feat/hpp-fcl). However, it proves to be very computationally expensive, and we are not sure should be proceed with development of this feature or not. Any comments on that matter are more than welcome!

Any further suggestions would be welcome, waiting for your feedback!