### PR TITLE
Self-collision barrier jacobian fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+### Fixed
+- `SelfCollisionBarrier` jacobian computation is fixed for floating body robots.
 
 ## [3.0.0] - 2024-07-29
 


### PR DESCRIPTION
This PR addresses two issues I've encountered while working with self-collision barriers:
 * It raised a dimension error when applied to floating base robots 
 * It raised an error, when there were more than two floating objects in the model (f.e. when some external obstacles appear, which are not a part of the robot)

Both problems were related to the jacobian computation, i.e. `SelfCollisionBarrier.compute_jacobian()` method:
*  The first problem was a trivial typo in Jacobian shape: the second dimension was `robot.nq` instead of `robot.nv`.
* The second problem was a little bit more tricky: as far as I understood, floating bodies have a parent joint (i.e. root joint), but they do not have a parent frame. Previously, the implementation of the barrier referred to the parent frame, which resulted in the error for floating bodies. The new implementation refers to joints instead.

I have checked the new implementation in some of my side projects, but I could port the examples there, just for completeness. Alternatively, we might introduce new tests that check that behaviour, if you wish.

Thanks to @simeon-ned and @RumblingTurtle for their support in finding problems and finding solutions to the issues.