### PR TITLE
Update self-collision barrier unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CICD: Update checkout action to v4
 - Update supported Python versions to 3.9–3.12
 
+### Fixed
+
+- CICD: Update unit test for self-collision barrier
+
 ## [3.1.0] - 2024-10-28
 
 ### Added

--- a/tests/test_self_collision_barrier.py
+++ b/tests/test_self_collision_barrier.py
@@ -35,7 +35,6 @@ class TestSelfCollisionBarrier(unittest.TestCase):
         )
 
         self.non_colliding_objects_pair_id = 5
-        self.colliding_objects_pair_id = 24  # Between second and third bodies
         self.q0 = np.zeros(self.robot.model.nq)
         self.robot.collision_data = process_collision_pairs(
             self.robot.model, self.robot.collision_model
@@ -126,8 +125,20 @@ class TestSelfCollisionBarrier(unittest.TestCase):
             n_collision_pairs=len(self.robot.collision_model.collisionPairs),
             d_min=0.02,
         )
-        h = barrier.compute_barrier(self.configuration)
-        self.assertTrue(np.all(h[self.colliding_objects_pair_id] < 0))
+        # See https://github.com/stephane-caron/pink/pull/129 for an
+        # illustration of this test configuration
+        q_test = np.zeros(self.robot.model.nq)
+        q_test[1] = 2.0
+        q_test[3] = -2.5
+        configuration = Configuration(
+            self.robot.model,
+            self.robot.data,
+            q_test,
+            collision_model=self.robot.collision_model,
+            collision_data=self.robot.collision_data,
+        )
+        h = barrier.compute_barrier(configuration)
+        self.assertTrue(np.min(h) < 0)  # there is a collision
 
     def test_closest_collision_pairs(self):
         """Test that the closest collision pairs are considered if number of


### PR DESCRIPTION
This PR investigates https://github.com/stephane-caron/pink/issues/130.

## Failing unit test

The test considers the following collision pair:

```py
        self.colliding_objects_pair_id = 24  # Between second and third bodies
```

Indeed, pair 24 is between bodies `iiwa_link_2_0` and `iiwa_link_3_1` of the iiwa14 description:

```
In [12]: first = self.configuration.collision_model.collisionPairs[24].first

In [13]: second = self.configuration.collision_model.collisionPairs[24].second

In [14]: self.configuration.collision_model.geometryObjects[first].name
Out[14]: 'iiwa_link_2_0'

In [15]: self.configuration.collision_model.geometryObjects[second].name
Out[15]: 'iiwa_link_3_1'
```

However, the test checks `h[self.colliding_objects_pair_id]`, where the ordering of the barrier vector `h` depends on sorted distances:

```py
        closest_pairs_idxs = np.argpartition(-distances, -self.dim)[
            -self.dim :
        ]

        return distances[closest_pairs_idxs]
```

If this analysis is correct, ``h[self.colliding_objects_pair_id]`` may not correspond to the distance for pair 24 after sorting, so it will not necessarily be negative 🤔

## Proposed update

This PR updates the test to:

1. Put the robot in the following configuration:

![image](https://github.com/user-attachments/assets/a47491a0-e017-48a2-a5c8-612a2786caa2)

2. Check that the lowest value in `h` is negative (as there is a self-collision)