### PR TITLE
Remove dependency on quadprog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
                       numpy
                       pinocchio>=2.6.4
                       qpsolvers>=2.7.2
-                      quadprog>=0.1.11
                       robot_descriptions>=1.9.0
                   cache-environment: true
                   post-cleanup: 'all'
@@ -80,7 +79,6 @@ jobs:
                       pinocchio>=2.6.4
                       pylint>=2.8.2
                       qpsolvers>=2.7.2
-                      quadprog>=0.1.11
                       robot_descriptions>=1.9.0
                       ruff>=0.4.3
                   cache-environment: true
@@ -123,7 +121,6 @@ jobs:
                       python=${{ matrix.python-version }}
                       pinocchio>=2.6.4
                       qpsolvers>=2.7.2
-                      quadprog>=0.1.11
                       robot_descriptions>=1.9.0
                   cache-environment: true
                   post-cleanup: 'all'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "numpy >=1.19.0",
     "pin >=2.6.3",
     "qpsolvers >=4.3.1",
-    "quadprog >=0.1.11",
 ]
 keywords = ["inverse", "kinematics", "pinocchio"]
 


### PR DESCRIPTION
This PR changes the default solve to `osqp` which is Apache-2.0 instead of `quadprog` which is GPL. GPL requires all subsequent libraries that use this code to also release as GPL if distributing code. The change to osqp would help mitigate GPL licencing issues for downstream use of the pin-pink library.