### PR TITLE
Update default QP solvers used in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- examples: Detail that quadprog works best on Stretch examples
 - examples: Installation instruction for loop-rate-limiters
+- examples: Switch to DAQP solvers in examples where it works well
+- examples: Switch to ProxQP on JVRC-1 example
+- examples: Switch to ProxQP on one-dof configuration limit example
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- examples: Installation instruction for loop-rate-limiters
+
 ### Changed
 
 - CICD: Switch from tox to Anaconda environments

--- a/examples/arm_kinova_gen2.py
+++ b/examples/arm_kinova_gen2.py
@@ -66,8 +66,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=200.0, warn=False)
     dt = rate.period

--- a/examples/arm_kinova_gen2.py
+++ b/examples/arm_kinova_gen2.py
@@ -6,16 +6,23 @@
 
 """Kinova Gen2 arm tracking a moving target."""
 
-import meshcat_shapes
 import numpy as np
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask
 from pink.utils import custom_configuration_vector
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description
@@ -56,7 +63,6 @@ if __name__ == "__main__":
     for task in tasks:
         task.set_target_from_configuration(configuration)
     viz.display(configuration.q)
-
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]

--- a/examples/arm_ur3.py
+++ b/examples/arm_ur3.py
@@ -67,8 +67,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=200.0, warn=False)
     dt = rate.period

--- a/examples/arm_ur3.py
+++ b/examples/arm_ur3.py
@@ -6,16 +6,23 @@
 
 """Universal Robots UR3 arm tracking a moving target."""
 
-import meshcat_shapes
 import numpy as np
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask
 from pink.utils import custom_configuration_vector
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description
@@ -57,7 +64,6 @@ if __name__ == "__main__":
     for task in tasks:
         task.set_target_from_configuration(configuration)
     viz.display(configuration.q)
-
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]

--- a/examples/arm_ur3_velocity_smoothing.py
+++ b/examples/arm_ur3_velocity_smoothing.py
@@ -7,17 +7,24 @@
 """UR3 arm tracking a target, first without then with velocity smoothing."""
 
 import matplotlib.pyplot as plt
-import meshcat_shapes
 import numpy as np
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.limits import AccelerationLimit
 from pink.tasks import DampingTask, FrameTask, PostureTask
 from pink.utils import custom_configuration_vector
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/arm_ur3_velocity_smoothing.py
+++ b/examples/arm_ur3_velocity_smoothing.py
@@ -79,8 +79,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=200.0, warn=False)
     dt = rate.period

--- a/examples/arm_ur5.py
+++ b/examples/arm_ur5.py
@@ -67,8 +67,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=200.0, warn=False)
     dt = rate.period

--- a/examples/arm_ur5.py
+++ b/examples/arm_ur5.py
@@ -6,16 +6,23 @@
 
 """Universal Robots UR5 arm tracking a moving target."""
 
-import meshcat_shapes
 import numpy as np
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask
 from pink.utils import custom_configuration_vector
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/barriers/arm_ur5.py
+++ b/examples/barriers/arm_ur5.py
@@ -10,7 +10,6 @@ import argparse
 
 import numpy as np
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
 import meshcat_shapes
 import pink
@@ -18,6 +17,14 @@ from pink import solve_ik
 from pink.barriers import PositionBarrier
 from pink.tasks import FrameTask, PostureTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/barriers/go2_squat.py
+++ b/examples/barriers/go2_squat.py
@@ -6,17 +6,24 @@
 
 """Go2 squat with z-axis barrier."""
 
-import meshcat_shapes
 import numpy as np
-import qpsolvers
-from loop_rate_limiters import RateLimiter
 import pinocchio as pin
+import qpsolvers
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.barriers import PositionBarrier
 from pink.tasks import FrameTask, PostureTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/barriers/yumi_self_collision.py
+++ b/examples/barriers/yumi_self_collision.py
@@ -7,17 +7,24 @@
 """Yumi two-armed manipulator with definition of custom frame and
 collision avoidance w.r.t. those frames."""
 
-import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.barriers import BodySphericalBarrier
 from pink.tasks import FrameTask, PostureTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/double_pendulum.py
+++ b/examples/double_pendulum.py
@@ -68,8 +68,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=100.0, warn=False)
     dt = rate.period

--- a/examples/double_pendulum.py
+++ b/examples/double_pendulum.py
@@ -8,16 +8,23 @@
 
 import os
 
-import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 if __name__ == "__main__":
     # Load robot description

--- a/examples/flying_dual_arm_ur3.py
+++ b/examples/flying_dual_arm_ur3.py
@@ -175,8 +175,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=200.0, warn=False)
     dt = rate.period

--- a/examples/flying_dual_arm_ur3.py
+++ b/examples/flying_dual_arm_ur3.py
@@ -9,17 +9,24 @@
 from typing import Tuple
 
 import hppfcl as fcl
-import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask
 from pink.utils import custom_configuration_vector
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description
@@ -127,7 +134,6 @@ if __name__ == "__main__":
     meshcat_shapes.frame(viewer["left_ee_target"], opacity=0.5)
     meshcat_shapes.frame(viewer["right_ee"], opacity=1.0)
     meshcat_shapes.frame(viewer["right_ee_target"], opacity=0.5)
-
 
     base_task = FrameTask(
         "base",

--- a/examples/humanoid_draco3.py
+++ b/examples/humanoid_draco3.py
@@ -161,8 +161,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=200.0, warn=False)
     dt = rate.period

--- a/examples/humanoid_draco3.py
+++ b/examples/humanoid_draco3.py
@@ -9,13 +9,20 @@
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
 import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, JointCouplingTask, PostureTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description
@@ -63,7 +70,6 @@ if __name__ == "__main__":
     viz = start_meshcat_visualizer(robot)
     wrist_frame = viz.viewer["right_wrist_pose"]
     meshcat_shapes.frame(wrist_frame)
-
 
     # Set initial robot configuration
     configuration = pink.Configuration(robot.model, robot.data, robot.q0)

--- a/examples/humanoid_g1_com.py
+++ b/examples/humanoid_g1_com.py
@@ -9,12 +9,19 @@
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
 import pink
 from pink import solve_ik
 from pink.tasks import ComTask, FrameTask, PostureTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/humanoid_jvrc.py
+++ b/examples/humanoid_jvrc.py
@@ -6,16 +6,23 @@
 
 """JVRC-1 humanoid standing on two feet and reaching with a hand."""
 
-import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/humanoid_jvrc.py
+++ b/examples/humanoid_jvrc.py
@@ -120,8 +120,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "proxqp" in qpsolvers.available_solvers:
+        solver = "proxqp"
 
     rate = RateLimiter(frequency=200.0, warn=False)
     dt = rate.period

--- a/examples/humanoid_sigmaban.py
+++ b/examples/humanoid_sigmaban.py
@@ -6,16 +6,23 @@
 
 """SigmaBan humanoid standing on two feet."""
 
-import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/humanoid_sigmaban.py
+++ b/examples/humanoid_sigmaban.py
@@ -103,8 +103,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=200.0, warn=False)
     dt = rate.period

--- a/examples/mobile_omni_wheeled_robot.py
+++ b/examples/mobile_omni_wheeled_robot.py
@@ -64,8 +64,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=100.0, warn=False)
     dt = rate.period

--- a/examples/mobile_omni_wheeled_robot.py
+++ b/examples/mobile_omni_wheeled_robot.py
@@ -11,16 +11,23 @@ Illustrates the notion of screw path.
 
 import os
 
-import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 if __name__ == "__main__":
     # Load robot description

--- a/examples/mobile_stretch.py
+++ b/examples/mobile_stretch.py
@@ -13,7 +13,7 @@ import qpsolvers
 
 import meshcat_shapes
 import pink
-from pink import solve_ik
+from pink import PinkError, solve_ik
 from pink.tasks import FrameTask
 from pink.visualization import start_meshcat_visualizer
 
@@ -99,7 +99,16 @@ if __name__ == "__main__":
         )
 
         # Compute velocity and integrate it into next configuration
-        velocity = solve_ik(configuration, tasks, dt, solver=solver)
+        try:
+            velocity = solve_ik(configuration, tasks, dt, solver=solver)
+        except PinkError as exn:
+            if solver != "quadprog":
+                raise PinkError(
+                    "IK failed as detailed in the traceback above. "
+                    f"Note that `solve_ik` was called with {solver=}, "
+                    "but this example works better with solver='quadprog'."
+                ) from exn
+            raise exn
         configuration.integrate_inplace(velocity, dt)
 
         # Visualize result at fixed FPS

--- a/examples/mobile_stretch.py
+++ b/examples/mobile_stretch.py
@@ -7,16 +7,23 @@
 
 """Move a Stretch RE1 with a fixed fingertip target around the origin."""
 
-import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/one_dof_configuration_limit.py
+++ b/examples/one_dof_configuration_limit.py
@@ -88,8 +88,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "proxqp" in qpsolvers.available_solvers:
+        solver = "proxqp"
 
     # Run closed-loop inverse kinematics
     rate = RateLimiter(frequency=100.0, warn=False)

--- a/examples/stretch_relative_target.py
+++ b/examples/stretch_relative_target.py
@@ -7,16 +7,23 @@
 
 """Move a Stretch RE1 with a fingertip target in the mobile-base frame."""
 
-import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, RelativeFrameTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/stretch_world_target.py
+++ b/examples/stretch_world_target.py
@@ -13,7 +13,7 @@ import qpsolvers
 
 import meshcat_shapes
 import pink
-from pink import solve_ik
+from pink import PinkError, solve_ik
 from pink.tasks import FrameTask
 from pink.visualization import start_meshcat_visualizer
 
@@ -104,7 +104,17 @@ if __name__ == "__main__":
         )
 
         # Compute velocity and integrate it into next configuration
-        velocity = solve_ik(configuration, tasks, dt, solver=solver)
+        try:
+            velocity = solve_ik(configuration, tasks, dt, solver=solver)
+        except PinkError as exn:
+            if solver != "quadprog":
+                raise PinkError(
+                    "IK failed as detailed in the traceback above. "
+                    f"Note that `solve_ik` was called with {solver=}, "
+                    "but this example works better with solver='quadprog'."
+                ) from exn
+            raise exn
+
         configuration.integrate_inplace(velocity, dt)
 
         # Visualize result at fixed FPS

--- a/examples/stretch_world_target.py
+++ b/examples/stretch_world_target.py
@@ -7,16 +7,23 @@
 
 """Move a Stretch RE1 with a fixed fingertip target around the origin."""
 
-import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
+import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/upkie_crouching.py
+++ b/examples/upkie_crouching.py
@@ -78,8 +78,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=200.0, warn=False)
     dt = rate.period

--- a/examples/upkie_crouching.py
+++ b/examples/upkie_crouching.py
@@ -9,13 +9,20 @@
 import meshcat_shapes
 import numpy as np
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask
 from pink.utils import custom_configuration_vector
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/upkie_rolling.py
+++ b/examples/upkie_rolling.py
@@ -8,12 +8,19 @@ import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, RollingTask
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/visualize_in_meshcat.py
+++ b/examples/visualize_in_meshcat.py
@@ -83,8 +83,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     rate = RateLimiter(frequency=200.0, warn=False)
     dt = rate.period

--- a/examples/visualize_in_meshcat.py
+++ b/examples/visualize_in_meshcat.py
@@ -9,7 +9,6 @@
 import numpy as np
 import pinocchio as pin
 import qpsolvers
-from loop_rate_limiters import RateLimiter
 
 import meshcat_shapes
 import pink
@@ -17,6 +16,14 @@ from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask
 from pink.utils import custom_configuration_vector
 from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description
@@ -73,7 +80,6 @@ if __name__ == "__main__":
 
     left_contact_target = tasks["left_contact"].transform_target_to_world
     right_contact_target = tasks["right_contact"].transform_target_to_world
-
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]

--- a/examples/visualize_in_yourdfpy.py
+++ b/examples/visualize_in_yourdfpy.py
@@ -78,8 +78,8 @@ if __name__ == "__main__":
 
     # Select QP solver
     solver = qpsolvers.available_solvers[0]
-    if "quadprog" in qpsolvers.available_solvers:
-        solver = "quadprog"
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
 
     animation_time = 0.0  # [s]
     visualizer_fps = 100  # [Hz]

--- a/examples/visualize_in_yourdfpy.py
+++ b/examples/visualize_in_yourdfpy.py
@@ -10,12 +10,19 @@ import numpy as np
 import pinocchio as pin
 import qpsolvers
 import yourdfpy
-from loop_rate_limiters import RateLimiter
 
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask
 from pink.utils import custom_configuration_vector
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
 
 try:
     from robot_descriptions import upkie_description

--- a/pink/__init__.py
+++ b/pink/__init__.py
@@ -8,6 +8,7 @@
 """Inverse kinematics for articulated robot models, based on Pinocchio."""
 
 from .configuration import Configuration
+from .exceptions import PinkError
 from .solve_ik import build_ik, solve_ik
 from .tasks import (
     FrameTask,
@@ -25,9 +26,10 @@ __all__ = [
     "FrameTask",
     "JointCouplingTask",
     "LinearHolonomicTask",
+    "PinkError",
     "PostureTask",
+    "Task",
     "build_ik",
     "custom_configuration_vector",
     "solve_ik",
-    "Task",
 ]


### PR DESCRIPTION
This PR follows up to https://github.com/stephane-caron/pink/issues/131.

It switches the default solver in examples to DAQP, except in the following cases:

- All Stretch examples, which in my tests today only worked well with quadprog for now
- Switch to ProxQP on JVRC-1 example
- Switch to ProxQP on one-dof configuration limit example

It also re-raises failed imports of loop rate limiters to hint at the corresponding package name on conda-forge and PyPI.