### PR TITLE
Release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0] - 2025-04-22
+
 ### Added
 
 - Add `NoSolutionFound` exception
@@ -23,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CICD: Update QP solvers used in unit tests
 - CICD: Update checkout action to v4
 - Raise custom `NoSolutionFound` rather than `AssertionError` in `solve_ik`
-- Update supported Python versions to 3.9–3.12
+- Update supported Python versions
 
 ### Fixed
 
@@ -357,7 +359,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Python package infrastructure
 
-[unreleased]: https://github.com/qpsolvers/qpsolvers/compare/v3.1.0...HEAD
+[unreleased]: https://github.com/qpsolvers/qpsolvers/compare/v3.2.0...HEAD
+[3.2.0]: https://github.com/qpsolvers/qpsolvers/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/qpsolvers/qpsolvers/compare/v3.0.0...v3.1.0
 [3.0.0]: https://github.com/qpsolvers/qpsolvers/compare/v2.1.0...v3.0.0
 [2.1.0]: https://github.com/qpsolvers/qpsolvers/compare/v2.0.0...v2.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "Pink: Python inverse kinematics based on Pinocchio"
-version: 3.1.0
-date-released: 2024-10-28
+version: 3.2.0
+date-released: 2025-04-22
 url: "https://github.com/stephane-caron/pink"
 license: "Apache-2.0"
 authors:

--- a/README.md
+++ b/README.md
@@ -162,15 +162,17 @@ Install the library and use it! Report bugs in the [issue tracker](https://githu
 If you use Pink in your scientific works, please cite it *e.g.* as follows:
 
 ```bibtex
-@software{pink2024,
+@software{pink,
   title = {{Pink: Python inverse kinematics based on Pinocchio}},
   author = {Caron, Stéphane and De Mont-Marin, Yann and Budhiraja, Rohan and Bang, Seung Hyeon and Domrachev, Ivan and Nedelchev, Simeon},
   license = {Apache-2.0},
   url = {https://github.com/stephane-caron/pink},
-  version = {3.1.0},
-  year = {2024}
+  version = {3.2.0},
+  year = {2025}
 }
 ```
+
+Don't forget to add yourself to the BibTeX above and to `CITATION.cff` if you contribute code to this repository.
 
 ## See also
 

--- a/pink/__init__.py
+++ b/pink/__init__.py
@@ -19,7 +19,7 @@ from .tasks import (
 )
 from .utils import custom_configuration_vector
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 __all__ = [
     "Configuration",


### PR DESCRIPTION
This release introduces the `NoSolutionFound` exception (previously an `AssertionError`), and makes a stricter check that the QP solver reports successfully converging to a solution. It is still possible to catch cases where the solver converged (but not to a solution) as follows:

```py
try:
    velocity = solve_ik(configuration, tasks, dt, solver=solver)
except NoSolutionFound as exn:
    if exn.results.x is not None:  # QP solver converged but not to a solution
        velocity = exn.results.x
    raise exn
```

This release also removes an unrequired dependency on [quadprog](https://github.com/quadprog/quadprog). This solver is still great for IK, but we cannot distribute it with Pink (permissive license: Apache-2.0) as it is GPL license. Feel free to install and use it on your own!

### Added

- Add `NoSolutionFound` exception
- Add `open` keyword argument to `start_meshcat_visualizer`
- examples: Detail that quadprog works best on Stretch examples
- examples: Installation instruction for loop-rate-limiters
- examples: Switch to DAQP solvers in examples where it works well
- examples: Switch to ProxQP on JVRC-1 example
- examples: Switch to ProxQP on one-dof configuration limit example

### Changed

- CICD: Switch from tox to Anaconda environments
- CICD: Update QP solvers used in unit tests
- CICD: Update checkout action to v4
- Raise custom `NoSolutionFound` rather than `AssertionError` in `solve_ik`
- Update supported Python versions

### Fixed

- CICD: Update unit test for self-collision barrier

### Removed

- Remove dependency on quadprog (thanks to @peterd-NV)