### PR TITLE
Omniwheel task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- CICD: Unit test fixture for the rolling task
+- CICD: Unit test fixture for the omniwheel task
 - Introduce *constraints* to enforce tasks as QP equality constraints
 - Task: Add missing task `__repr__` functions
 - Task: Omniwheel task, like a rolling task but allowing lateral motion

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Introduce *constraints* to enforce tasks as QP equality constraints
 - Task: Add missing task `__repr__` functions
+- Task: Omniwheel task, like a rolling task but allowing lateral motion
 - Task: Report LM damping in CoM task representation
 
 ### Changed

--- a/pink/tasks/__init__.py
+++ b/pink/tasks/__init__.py
@@ -12,6 +12,7 @@ from .frame_task import FrameTask
 from .joint_coupling_task import JointCouplingTask
 from .linear_holonomic_task import LinearHolonomicTask
 from .low_acceleration_task import LowAccelerationTask
+from .omniwheel_task import OmniwheelTask
 from .posture_task import PostureTask
 from .relative_frame_task import RelativeFrameTask
 from .rolling_task import RollingTask
@@ -24,6 +25,7 @@ __all__ = [
     "JointCouplingTask",
     "LinearHolonomicTask",
     "LowAccelerationTask",
+    "OmniwheelTask",
     "PostureTask",
     "RelativeFrameTask",
     "RollingTask",

--- a/pink/tasks/frame_task.py
+++ b/pink/tasks/frame_task.py
@@ -127,10 +127,7 @@ class FrameTask(Task):
                 f"currently cost={self.cost}"
             )
 
-    def set_target(
-        self,
-        transform_target_to_world: pin.SE3,
-    ) -> None:
+    def set_target(self, transform_target_to_world: pin.SE3) -> None:
         """Set task target pose in the world frame.
 
         Args:

--- a/pink/tasks/omniwheel_task.py
+++ b/pink/tasks/omniwheel_task.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2024 Inria
+
+"""Omniwheel task implementation."""
+
+import numpy as np
+
+from ..configuration import Configuration
+from .rolling_task import RollingTask
+
+
+class OmniwheelTask(RollingTask):
+    r"""Roll without slipping on a plane, allowing lateral motion.
+
+    The name of this task comes from omniwheels, also known as poly wheels.
+    See the :class:`pink.tasks.rolling_task.RollingTask`.
+
+    Attributes:
+        hub_frame: Name of a frame attached to the hub of the wheel in the
+            robot model.
+        floor_frame: Name of the inertial frame whose xy-plane defines the
+            contact surface the wheel is rolling onto.
+        wheel_radius: Radius of the wheel, i.e. distance in meters from the hub
+            to the nearest point on the rim.
+
+    Note:
+        See also the similar `wheel task in the PlaCo C++ library
+        <https://github.com/Rhoban/placo/blob/9e65abadff45071ab11274eb74770d71e10b7ca8/docs/kinematics/wheel_task.rst>`__.
+    """
+
+    def compute_error(self, configuration: Configuration) -> np.ndarray:
+        r"""Compute the rolling task error.
+
+        The error is a 2D vector :math:`{}_R e(q)` of the rim frame :math:`R`:
+
+        .. math::
+
+            {}_R e(q) := \begin{bmatrix}
+                0 \\
+                z_{\mathit{hub}} - \rho
+                \end{bmatrix}
+
+        The error is zero along the x-axis of the rim frame to roll without
+        slipping (*i.e.*, the velocity of the contact point is zero in the
+        floor plane). The error along the z-axis of the rim frame is chosen so
+        that the task keeps the wheel hub at distance :math:`\rho` (wheel
+        radius) from the floor plane.
+
+        Args:
+            configuration: Robot configuration :math:`q`.
+
+        Returns:
+            Task error :math:`{}_R e(q) \in \mathbb{R}^3`, a translation
+            expressed in the rim frame :math:`R`.
+        """
+        rolling_error = super().compute_error(configuration)
+        return np.array([rolling_error[0], rolling_error[2]])
+
+    def compute_jacobian(self, configuration: Configuration) -> np.ndarray:
+        r"""Compute the omniwheel task Jacobian.
+
+        Args:
+            configuration: Robot configuration :math:`q`.
+
+        Returns:
+            Jacobian matrix :math:`{}_R J_{WR}`, expressed locally in the rim
+            frame :math:`R`, of shape :math:`(2, n_q)`.
+        """
+        rolling_jacobian = super().compute_jacobian(configuration)
+        return np.vstack([rolling_jacobian[0], rolling_jacobian[2]])
+
+    def __repr__(self):
+        """Human-readable representation of the task."""
+        rolling_repr = super().__repr__()
+        return rolling_repr.replace("RollingTask", "OmniwheelTask")

--- a/pink/tasks/rolling_task.py
+++ b/pink/tasks/rolling_task.py
@@ -6,7 +6,7 @@
 
 """Rolling task implementation."""
 
-from typing import Optional, Union, Sequence
+from typing import Optional, Sequence, Union
 
 import numpy as np
 import pinocchio as pin

--- a/pink/tasks/rolling_task.py
+++ b/pink/tasks/rolling_task.py
@@ -6,7 +6,7 @@
 
 """Rolling task implementation."""
 
-from typing import Optional
+from typing import Optional, Union, Sequence
 
 import numpy as np
 import pinocchio as pin
@@ -36,7 +36,6 @@ class RollingTask(Task):
     Note:
         See also the similar `wheel task in the PlaCo C++ library
         <https://github.com/Rhoban/placo/blob/9e65abadff45071ab11274eb74770d71e10b7ca8/docs/kinematics/wheel_task.rst>`__.
-        It additionally handles omniwheels.
     """
 
     hub_frame: str
@@ -48,7 +47,7 @@ class RollingTask(Task):
         hub_frame: str,
         floor_frame: str,
         wheel_radius: float,
-        cost: Optional[float],
+        cost: Optional[Union[float, Sequence[float], np.ndarray]],
         gain: float = 1.0,
         lm_damping: float = 0.0,
     ):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2022 Stéphane Caron
 
-"""Test the Configuration type."""
+"""Test the configuration type."""
 
 import unittest
 

--- a/tests/test_linear_holonomic_task.py
+++ b/tests/test_linear_holonomic_task.py
@@ -13,8 +13,8 @@ import pinocchio as pin
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
 from pink import Configuration
-from pink.tasks import LinearHolonomicTask
 from pink.exceptions import TaskDefinitionError, TaskJacobianNotSet
+from pink.tasks import LinearHolonomicTask
 from pink.utils import get_joint_idx
 
 

--- a/tests/test_omniwheel_task.py
+++ b/tests/test_omniwheel_task.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Inria
+
+"""Test fixture for the omniwheel task."""
+
+import unittest
+
+from pink import Configuration
+from pink.tasks import OmniwheelTask
+from robot_descriptions.loaders.pinocchio import load_robot_description
+
+
+class TestOmniwheelTask(unittest.TestCase):
+    """Test consistency of the omniwheel task.
+
+    Note:
+        This fixture only tests the task itself. Integration tests with the IK
+        are carried out in :class:`TestSolveIK`.
+    """
+
+    def setUp(self):
+        robot = load_robot_description("upkie_description")
+        left_wheel_task = OmniwheelTask(
+            "left_wheel_center",
+            floor_frame="universe",
+            wheel_radius=0.1,
+            cost=1.0,
+        )
+        self.configuration = Configuration(robot.model, robot.data, robot.q0)
+        self.left_wheel_task = left_wheel_task
+
+    def test_compute_error(self):
+        task = self.left_wheel_task
+        error_in_rim = task.compute_error(self.configuration)
+        self.assertAlmostEqual(error_in_rim[0], 0.0)
+
+    def test_compute_jacobian(self):
+        task = self.left_wheel_task
+        jacobian_hub_in_rim = task.compute_jacobian(self.configuration)
+        self.assertEqual(
+            jacobian_hub_in_rim.shape, (2, self.configuration.model.nv)
+        )

--- a/tests/test_omniwheel_task.py
+++ b/tests/test_omniwheel_task.py
@@ -8,9 +8,10 @@
 
 import unittest
 
+from robot_descriptions.loaders.pinocchio import load_robot_description
+
 from pink import Configuration
 from pink.tasks import OmniwheelTask
-from robot_descriptions.loaders.pinocchio import load_robot_description
 
 
 class TestOmniwheelTask(unittest.TestCase):

--- a/tests/test_rolling_task.py
+++ b/tests/test_rolling_task.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2025 Inria
+
+"""Test fixture for the rolling task."""
+
+import unittest
+
+import numpy as np
+import pinocchio as pin
+from pink import Configuration
+from pink.exceptions import TargetNotSet, TaskDefinitionError
+from pink.tasks import RollingTask
+from qpsolvers import solve_qp
+from robot_descriptions.loaders.pinocchio import load_robot_description
+
+
+class TestRollingTask(unittest.TestCase):
+    """Test consistency of the rolling task.
+
+    Note:
+        This fixture only tests the task itself. Integration tests with the IK
+        are carried out in :class:`TestSolveIK`.
+    """
+
+    def setUp(self):
+        robot = load_robot_description("upkie_description")
+        left_wheel_task = RollingTask(
+            "left_wheel_center",
+            floor_frame="universe",
+            wheel_radius=0.1,
+            cost=1.0,
+        )
+        self.configuration = Configuration(robot.model, robot.data, robot.q0)
+        self.left_wheel_task = left_wheel_task
+
+    def test_compute_error(self):
+        task = self.left_wheel_task
+        error_in_rim = task.compute_error(self.configuration)
+        self.assertAlmostEqual(np.linalg.norm(error_in_rim[:2]), 0.0)
+
+    def test_compute_jacobian(self):
+        task = self.left_wheel_task
+        jacobian_hub_in_rim = task.compute_jacobian(self.configuration)
+        self.assertEqual(
+            jacobian_hub_in_rim.shape, (3, self.configuration.model.nv)
+        )

--- a/tests/test_rolling_task.py
+++ b/tests/test_rolling_task.py
@@ -9,12 +9,10 @@
 import unittest
 
 import numpy as np
-import pinocchio as pin
-from pink import Configuration
-from pink.exceptions import TargetNotSet, TaskDefinitionError
-from pink.tasks import RollingTask
-from qpsolvers import solve_qp
 from robot_descriptions.loaders.pinocchio import load_robot_description
+
+from pink import Configuration
+from pink.tasks import RollingTask
 
 
 class TestRollingTask(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,16 +7,20 @@
 
 """Test fixture for other library features."""
 
+import os
 import unittest
 
-import os
 import numpy as np
 import pinocchio as pin
-from robot_descriptions.loaders.pinocchio import load_robot_description
 from robot_descriptions.iiwa14_description import PACKAGE_PATH, REPOSITORY_PATH
+from robot_descriptions.loaders.pinocchio import load_robot_description
 
 from pink.exceptions import ConfigurationError
-from pink.utils import VectorSpace, custom_configuration_vector, process_collision_pairs
+from pink.utils import (
+    VectorSpace,
+    custom_configuration_vector,
+    process_collision_pairs,
+)
 
 
 class TestUtils(unittest.TestCase):
@@ -28,7 +32,9 @@ class TestUtils(unittest.TestCase):
         Assumes the left and right knees have joint indices respectively 8 and
         11 in the configuration vector.
         """
-        robot = load_robot_description("upkie_description", root_joint=pin.JointModelFreeFlyer())
+        robot = load_robot_description(
+            "upkie_description", root_joint=pin.JointModelFreeFlyer()
+        )
         q = custom_configuration_vector(robot, left_knee=0.2, right_knee=-0.2)
         self.assertAlmostEqual(q[8], 0.2)
         self.assertAlmostEqual(q[11], -0.2)
@@ -46,7 +52,9 @@ class TestUtils(unittest.TestCase):
 
     def test_vector_space(self):
         """Check dimensions of regular tangent space."""
-        robot = load_robot_description("upkie_description", root_joint=pin.JointModelFreeFlyer())
+        robot = load_robot_description(
+            "upkie_description", root_joint=pin.JointModelFreeFlyer()
+        )
         nv = robot.model.nv
         tangent = VectorSpace(robot.model.nv)
         self.assertEqual(tangent.eye.shape, (nv, nv))
@@ -54,18 +62,32 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(tangent.zeros.shape, (nv,))
 
     def test_process_collision_pairs(self):
-        urdf_path = os.path.join(PACKAGE_PATH, "urdf", "iiwa14_spheres_collision.urdf")
-        robot = pin.RobotWrapper.BuildFromURDF(urdf_path, package_dirs=[os.path.dirname(REPOSITORY_PATH)])
+        urdf_path = os.path.join(
+            PACKAGE_PATH, "urdf", "iiwa14_spheres_collision.urdf"
+        )
+        robot = pin.RobotWrapper.BuildFromURDF(
+            urdf_path, package_dirs=[os.path.dirname(REPOSITORY_PATH)]
+        )
 
-        robot.collision_data = process_collision_pairs(robot.model, robot.collision_model)
+        robot.collision_data = process_collision_pairs(
+            robot.model, robot.collision_model
+        )
 
         # The contacts are enabled
         self.assertTrue(robot.collision_data.enable_contact)
         # The amount of total collision pairs is 72
         self.assertEqual(len(robot.collision_data.distanceResults), 72)
 
-        # If sample srdf file is taken, the number of collision pairs shoul reduce
-        robot = pin.RobotWrapper.BuildFromURDF(urdf_path, package_dirs=[os.path.dirname(REPOSITORY_PATH)])
-        srdf_path = os.path.dirname(os.path.realpath(__file__)) + "/iiwa_exclude_pairs.srdf"
-        robot.collision_data = process_collision_pairs(robot.model, robot.collision_model, srdf_path=srdf_path)
+        # If sample srdf file is taken, the number of collision pairs should
+        # reduce
+        robot = pin.RobotWrapper.BuildFromURDF(
+            urdf_path, package_dirs=[os.path.dirname(REPOSITORY_PATH)]
+        )
+        srdf_path = (
+            os.path.dirname(os.path.realpath(__file__))
+            + "/iiwa_exclude_pairs.srdf"
+        )
+        robot.collision_data = process_collision_pairs(
+            robot.model, robot.collision_model, srdf_path=srdf_path
+        )
         self.assertTrue(len(robot.collision_data.distanceResults) < 72)


### PR DESCRIPTION
This PR adds the omniwheel task, a straightforward derivative of the rolling task that allows lateral motion.

See also the similar [wheel task in the PlaCo C++ library](https://github.com/Rhoban/placo/blob/9e65abadff45071ab11274eb74770d71e10b7ca8/docs/kinematics/wheel_task.rst).