### PR TITLE
Add joint velocity task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Task: `JointVelocityTask` for tracking a reference joint-velocity trajectory
+
 ## [3.3.0] - 2025-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move pink.barriers.exceptions to pink.exceptions
 - Move pink.tasks.exceptions to pink.exceptions
 - Task: Make `__repr__` of base class abstract to ensure tasks define their own
+- docs: Correct objective-function formula (thanks to @aescande)
 - docs: Refactor Tasks page and update references
 - examples: Update installation hints when example dependencies are missing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Task: `JointVelocityTask` for tracking a reference joint-velocity trajectory
 
+### Fixed
+
+- Save problem instance in `NoSolutionFound` exception
+
 ### Removed
 
 - Remove unused attribute of `SelfCollisionBarrier`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Task: `JointVelocityTask` for tracking a reference joint-velocity trajectory
 
+### Removed
+
+- Remove unused attribute of `SelfCollisionBarrier`
+
 ## [3.3.0] - 2025-05-15
 
 ### Added

--- a/examples/arm_z1_joint_velocity_tracking.py
+++ b/examples/arm_z1_joint_velocity_tracking.py
@@ -32,9 +32,9 @@ except ModuleNotFoundError:
 
 if __name__ == "__main__":
     print(
-        "In this example, the arm tracks a reference sinusoidal "
-        "joint-velocity trajectory that is unfeasible at times.\n"
-        "The trajectory is tracked while within joint limits."
+        "In this example, the arm tracks a sinusoidal joint-velocity "
+        "trajectory that is unfeasible at times.\nThe trajectory is only "
+        "tracked while the robot stays within joint limits."
     )
     robot = load_robot_description("z1_description")
     viz = start_meshcat_visualizer(robot)

--- a/examples/arm_z1_joint_velocity_tracking.py
+++ b/examples/arm_z1_joint_velocity_tracking.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unitree Z1 arm tracking a reference joint-velocity trajectory."""
+
+import numpy as np
+import qpsolvers
+
+import pink
+from pink import solve_ik
+from pink.tasks import JointVelocityTask
+from pink.visualization import start_meshcat_visualizer
+
+try:
+    from loop_rate_limiters import RateLimiter
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(
+        "Examples use loop rate limiters, "
+        "try `[conda|pip] install loop-rate-limiters`"
+    ) from exc
+
+try:
+    from robot_descriptions.loaders.pinocchio import load_robot_description
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        "Examples need robot_descriptions, "
+        "try `[conda|pip] install robot_descriptions`"
+    )
+
+
+if __name__ == "__main__":
+    print(
+        "In this example, the arm tracks a reference sinusoidal "
+        "joint-velocity trajectory that is unfeasible at times.\n"
+        "The trajectory is tracked while within joint limits."
+    )
+    robot = load_robot_description("z1_description")
+    viz = start_meshcat_visualizer(robot)
+    configuration = pink.Configuration(robot.model, robot.data, robot.q0)
+    viz.display(configuration.q)
+
+    # Our only task in this example is a joint-velocity task
+    joint_velocity_task = JointVelocityTask(cost=1.0)
+
+    # Select a QP solver
+    solver = qpsolvers.available_solvers[0]
+    if "daqp" in qpsolvers.available_solvers:
+        solver = "daqp"
+
+    rate = RateLimiter(frequency=200.0, warn=False)
+    dt = rate.period
+    t = 0.0  # [s]
+    while True:
+        target_velocity = 2.0 * np.sin(t) * np.ones(robot.nv)
+        joint_velocity_task.set_target(target_velocity, dt)
+        velocity = solve_ik(
+            configuration,
+            tasks=[joint_velocity_task],
+            dt=dt,
+            solver=solver,
+        )
+        configuration.integrate_inplace(velocity, dt)
+        viz.display(configuration.q)
+        rate.sleep()
+        t += dt

--- a/examples/inverse_kinematics_ur10.py
+++ b/examples/inverse_kinematics_ur10.py
@@ -6,6 +6,7 @@
 """Move the end-effector of a UR10 arm to a prescribed target."""
 
 import numpy as np
+import pinocchio as pin
 import pinocchio
 import qpsolvers
 
@@ -31,22 +32,22 @@ if __name__ == "__main__":
     joint_name = robot.model.names[-1]
     parent_joint = robot.model.getJointId(joint_name)
     parent_frame = robot.model.getFrameId(joint_name)
-    placement = pinocchio.SE3.Identity()
+    placement = pin.SE3.Identity()
 
     FRAME_NAME = "ee_frame"
     ee_frame = robot.model.addFrame(
-        pinocchio.Frame(
+        pin.Frame(
             FRAME_NAME,
             parent_joint,
             parent_frame,
             placement,
-            pinocchio.FrameType.OP_FRAME,
+            pin.FrameType.OP_FRAME,
         )
     )
-    robot.data = pinocchio.Data(robot.model)
+    robot.data = pin.Data(robot.model)
     low = robot.model.lowerPositionLimit
     high = robot.model.upperPositionLimit
-    robot.q0 = pinocchio.neutral(robot.model)
+    robot.q0 = pin.neutral(robot.model)
 
     # Task details
     np.random.seed(0)
@@ -56,7 +57,7 @@ if __name__ == "__main__":
             for i in range(6)
         ]
     )
-    pinocchio.forwardKinematics(robot.model, robot.data, q_final)
+    pin.forwardKinematics(robot.model, robot.data, q_final)
     target_pose = robot.data.oMi[parent_joint]
     ee_task = FrameTask(FRAME_NAME, [1.0, 1.0, 1.0], [1.0, 1.0, 1.0])
     ee_task.set_target(target_pose)
@@ -79,9 +80,9 @@ if __name__ == "__main__":
                 else qpsolvers.available_solvers[0]
             ),
         )
-        q_out = pinocchio.integrate(robot.model, configuration.q, dv * dt)
+        q_out = pin.integrate(robot.model, configuration.q, dv * dt)
         configuration = pink.Configuration(robot.model, robot.data, q_out)
-        pinocchio.updateFramePlacements(robot.model, robot.data)
+        pin.updateFramePlacements(robot.model, robot.data)
         error_norm = np.linalg.norm(ee_task.compute_error(configuration))
         nb_steps += 1
 

--- a/pink/__init__.py
+++ b/pink/__init__.py
@@ -13,6 +13,7 @@ from .solve_ik import build_ik, solve_ik
 from .tasks import (
     FrameTask,
     JointCouplingTask,
+    JointVelocityTask,
     LinearHolonomicTask,
     PostureTask,
     Task,
@@ -25,6 +26,7 @@ __all__ = [
     "Configuration",
     "FrameTask",
     "JointCouplingTask",
+    "JointVelocityTask",
     "LinearHolonomicTask",
     "PinkError",
     "PostureTask",

--- a/pink/barriers/barrier.py
+++ b/pink/barriers/barrier.py
@@ -260,10 +260,20 @@ class Barrier(abc.ABC):
         Returns:
             str: String representation.
         """
+        safe_displacement = (
+            "no"
+            if np.allclose(self.safe_displacement_gain, 0)
+            else self.safe_displacement
+        )
+        safe_displacement_gain = (
+            "no"
+            if np.allclose(self.safe_displacement_gain, 0)
+            else self.safe_displacement_gain
+        )
         return (
             f"Barrier("
             f"gain={self.gain}, "
-            f"safe_displacement={'no' if np.allclose(self.safe_displacement_gain, 0) else self.safe_displacement}, "  # noqa: E501
-            f"safe_displacement_gain={'no' if np.allclose(self.safe_displacement_gain, 0) else self.safe_displacement_gain})"  # noqa: E501
+            f"{safe_displacement=}, "
+            f"{safe_displacement_gain=}, "
             f"dim={self.dim})"
         )

--- a/pink/barriers/self_collision_barrier.py
+++ b/pink/barriers/self_collision_barrier.py
@@ -82,7 +82,6 @@ class SelfCollisionBarrier(Barrier):
         )
 
         self.d_min = d_min
-        self.__q_prev = None
 
     def compute_barrier(self, configuration: Configuration) -> np.ndarray:
         r"""Compute the value of the barrier function.

--- a/pink/configuration.py
+++ b/pink/configuration.py
@@ -191,14 +191,13 @@ class Configuration:
                         q_min[i],
                         q_max[i],
                     )
-                else:
-                    logging.warning(
-                        "Value %f at index %d is out of limits: [%f, %f]",
-                        self.q[i],
-                        i,
-                        q_min[i],
-                        q_max[i],
-                    )
+                logging.warning(
+                    "Value %f at index %d is out of limits: [%f, %f]",
+                    self.q[i],
+                    i,
+                    q_min[i],
+                    q_max[i],
+                )
 
     def get_frame_jacobian(self, frame: str) -> np.ndarray:
         r"""Compute the Jacobian matrix of a frame velocity.

--- a/pink/exceptions.py
+++ b/pink/exceptions.py
@@ -52,7 +52,9 @@ class NoSolutionFound(PinkError):
     """The QP solver did not find a solution to the differential IK problem."""
 
     def __init__(
-        self, problem: qpsolvers.Problem, results: qpsolvers.Solution
+        self,
+        problem: qpsolvers.Problem,
+        results: qpsolvers.Solution,
     ) -> None:
         """Create exception.
 
@@ -63,6 +65,7 @@ class NoSolutionFound(PinkError):
         super().__init__(
             "QP solver did not find a solution to the differential IK problem"
         )
+        self.problem = problem
         self.results = results
 
 

--- a/pink/tasks/__init__.py
+++ b/pink/tasks/__init__.py
@@ -10,6 +10,7 @@ from .com_task import ComTask
 from .damping_task import DampingTask
 from .frame_task import FrameTask
 from .joint_coupling_task import JointCouplingTask
+from .joint_velocity_task import JointVelocityTask
 from .linear_holonomic_task import LinearHolonomicTask
 from .low_acceleration_task import LowAccelerationTask
 from .omniwheel_task import OmniwheelTask
@@ -23,6 +24,7 @@ __all__ = [
     "DampingTask",
     "FrameTask",
     "JointCouplingTask",
+    "JointVelocityTask",
     "LinearHolonomicTask",
     "LowAccelerationTask",
     "OmniwheelTask",

--- a/pink/tasks/damping_task.py
+++ b/pink/tasks/damping_task.py
@@ -29,11 +29,7 @@ class DampingTask(JointVelocityTask):
             cost: joint angular velocity cost, in
                 :math:`[\mathrm{cost}] [\mathrm{s}] / [\mathrm{rad}]`.
         """
-        super().__init__(
-            cost=cost,
-            gain=0.0,  # no gain: the task error is always zero
-            lm_damping=0.0,  # no LM damping: the task error is always zero
-        )
+        super().__init__(cost=cost)
 
     def compute_error(self, configuration: Configuration) -> np.ndarray:
         r"""Compute damping task error.

--- a/pink/tasks/damping_task.py
+++ b/pink/tasks/damping_task.py
@@ -10,20 +10,16 @@ import numpy as np
 
 from ..configuration import Configuration
 from ..utils import get_root_joint_dim
-from .posture_task import PostureTask
+from .joint_velocity_task import JointVelocityTask
 
 
-class DampingTask(PostureTask):
+class DampingTask(JointVelocityTask):
     r"""Minimize joint velocities.
 
     The damping task minimizes :math:`\| v \|_2` with :math:`v` the joint
     velocity resulting from differential IK. The word "damping" is used here by
     analogy with forces that fight against motion, and bring the robot to a
     rest if nothing else drives it.
-
-    Note:
-        The damping task is implemented as a special case of the
-        :class:`PostureTask` where the gain $\alpha$ is zero.
     """
 
     def __init__(self, cost: float) -> None:

--- a/pink/tasks/joint_velocity_task.py
+++ b/pink/tasks/joint_velocity_task.py
@@ -6,8 +6,6 @@
 
 """Joint velocity task."""
 
-from typing import Optional
-
 import numpy as np
 
 from ..configuration import Configuration
@@ -28,11 +26,7 @@ class JointVelocityTask(Task):
         (a.k.a. root joint in Pinocchio).
     """
 
-    target_v: Optional[np.ndarray]
-
-    def __init__(
-        self, cost: float, lm_damping: float = 0.0, gain: float = 1.0
-    ) -> None:
+    def __init__(self, cost: float) -> None:
         r"""Initialize task.
 
         Args:
@@ -41,8 +35,8 @@ class JointVelocityTask(Task):
         """
         super().__init__(
             cost=cost,
-            gain=gain,
-            lm_damping=lm_damping,
+            gain=0.0,  # no gain: the task error is directly a velocity
+            lm_damping=0.0,  # no LM damping either
         )
         self.target_v = None
 

--- a/pink/tasks/joint_velocity_task.py
+++ b/pink/tasks/joint_velocity_task.py
@@ -78,9 +78,16 @@ class JointVelocityTask(Task):
 
         .. math::
 
-            J(q) \Delta q = \Delta q = \alpha (q^* \ominus q)
+            J(q) \Delta q = \Delta q
 
-        See :func:`pink.tasks.task.Task.compute_jacobian` for more context.
+        Combining this with :math:`e(q) = \Delta q_{ref}` and :math:`\alpha =
+        1`, we get an overall velocity-tracking task dynamics:
+
+        .. math::
+
+            J(q) \Delta q = -\alpha e(q)
+            \quad \Leftrightarrow \quad
+            \Delta q = \Delta q_{ref}
 
         Args:
             configuration: Robot configuration :math:`q`.
@@ -88,8 +95,8 @@ class JointVelocityTask(Task):
         Returns:
             Joint-velocity task Jacobian :math:`J(q)`.
         """
-        _, nv = get_root_joint_dim(configuration.model)
-        return configuration.tangent.eye[nv:, :]
+        _, root_nv = get_root_joint_dim(configuration.model)
+        return configuration.tangent.eye[root_nv:, :]
 
     def __repr__(self):
         """Human-readable representation of the task."""

--- a/pink/tasks/joint_velocity_task.py
+++ b/pink/tasks/joint_velocity_task.py
@@ -6,6 +6,8 @@
 
 """Joint velocity task."""
 
+from typing import Optional
+
 import numpy as np
 
 from ..configuration import Configuration
@@ -39,7 +41,7 @@ class JointVelocityTask(Task):
             gain=1.0,  # unit gain as the task error is directly a velocity
             lm_damping=0.0,  # no Levenberg-Marquardt damping
         )
-        self.__target_Delta_q = None
+        self.__target_Delta_q: Optional[np.ndarray] = None
 
     def set_target(self, target_v: np.ndarray, dt: float) -> None:
         """Set target joint velocity.
@@ -68,7 +70,7 @@ class JointVelocityTask(Task):
         task_nv = configuration.model.nv - root_nv
         if self.__target_Delta_q is None:
             raise TargetNotSet(repr(self))
-        elif self.__target_Delta_q.shape[0] != task_nv:
+        if self.__target_Delta_q.shape[0] != task_nv:
             raise TaskDefinitionError(
                 f"Target has dimension nv={self.__target_Delta_q.shape[0]} "
                 f"but the task expects nv={task_nv} "

--- a/pink/tasks/joint_velocity_task.py
+++ b/pink/tasks/joint_velocity_task.py
@@ -9,7 +9,7 @@
 import numpy as np
 
 from ..configuration import Configuration
-from ..exceptions import TaskDefinitionError
+from ..exceptions import TaskDefinitionError, TargetNotSet
 from ..utils import get_root_joint_dim
 from .task import Task
 
@@ -59,11 +59,12 @@ class JointVelocityTask(Task):
             Joint-velocity task error.
         """
         _, root_nv = get_root_joint_dim(configuration.model)
-        target_nv = self.__target_Delta_q.shape[0]
         task_nv = configuration.model.nv - root_nv
-        if target_nv != task_nv:
+        if self.__target_Delta_q is None:
+            raise TargetNotSet(repr(self))
+        elif self.__target_Delta_q.shape[0] != task_nv:
             raise TaskDefinitionError(
-                f"Target has dimension nv={target_nv} "
+                f"Target has dimension nv={self.__target_Delta_q.shape[0]} "
                 f"but the task expects nv={task_nv} "
                 f"({configuration.model.nv=}, {root_nv=})"
             )

--- a/pink/tasks/joint_velocity_task.py
+++ b/pink/tasks/joint_velocity_task.py
@@ -46,6 +46,7 @@ class JointVelocityTask(Task):
 
         Args:
             target_v: Target joint-velocity vector in the tangent space.
+            dt: Integration duration in [s].
         """
         if target_v.ndim != 1:
             raise TaskDefinitionError(

--- a/pink/tasks/joint_velocity_task.py
+++ b/pink/tasks/joint_velocity_task.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 Inria
+
+"""Joint velocity task."""
+
+from typing import Optional
+
+import numpy as np
+
+from ..configuration import Configuration
+from ..utils import get_root_joint_dim
+from .task import Task
+
+
+class JointVelocityTask(Task):
+    r"""Track joint velocities.
+
+    This task minimizes :math:`\| v^{\mathit{ref}} - v \|_2` with :math:`v` the
+    joint velocity resulting from differential IK and :math:`v^{\mathit{ref}}`
+    is a reference joint-velocity vector.
+
+    Note:
+        Like the :class:`PostureTask`, this task does not apply to
+        floating-base coordinates if the robot model has a floating base
+        (a.k.a. root joint in Pinocchio).
+    """
+
+    target_v: Optional[np.ndarray]
+
+    def __init__(
+        self, cost: float, lm_damping: float = 0.0, gain: float = 1.0
+    ) -> None:
+        r"""Initialize task.
+
+        Args:
+            cost: Joint angular velocity cost, in
+                :math:`[\mathrm{cost}] [\mathrm{s}] / [\mathrm{rad}]`.
+        """
+        super().__init__(
+            cost=cost,
+            gain=gain,
+            lm_damping=lm_damping,
+        )
+        self.target_v = None
+
+    def set_target(self, target_v: np.ndarray) -> None:
+        """Set target joint velocity.
+
+        Args:
+            target_v: Target joint-velocity vector in the tangent space.
+        """
+        self.target_v = target_v.copy()
+
+    def compute_error(self, configuration: Configuration) -> np.ndarray:
+        r"""Compute the joint-velocity task error.
+
+        Args:
+            configuration: Robot configuration :math:`q`.
+
+        Returns:
+            Joint-velocity task error.
+        """
+        _, root_nv = get_root_joint_dim(configuration.model)
+        return np.zeros(configuration.model.nv - root_nv)
+
+    def compute_jacobian(self, configuration: Configuration) -> np.ndarray:
+        r"""Compute the joint-velocity task Jacobian.
+
+        The task Jacobian is the identity :math:`I_{n_v} \in \mathbb{R}^{n_v
+        \times n_v}`, with :math:`n_v` the dimension of the robot's tangent
+        space, so that the task dynamics are:
+
+        .. math::
+
+            J(q) \Delta q = \Delta q = \alpha (q^* \ominus q)
+
+        See :func:`pink.tasks.task.Task.compute_jacobian` for more context.
+
+        Args:
+            configuration: Robot configuration :math:`q`.
+
+        Returns:
+            Joint-velocity task Jacobian :math:`J(q)`.
+        """
+        _, nv = get_root_joint_dim(configuration.model)
+        return configuration.tangent.eye[nv:, :]
+
+    def __repr__(self):
+        """Human-readable representation of the task."""
+        return f"JointVelocityTask(cost={self.cost})"

--- a/pink/tasks/joint_velocity_task.py
+++ b/pink/tasks/joint_velocity_task.py
@@ -9,7 +9,7 @@
 import numpy as np
 
 from ..configuration import Configuration
-from ..exceptions import TaskDefinitionError, TargetNotSet
+from ..exceptions import TargetNotSet, TaskDefinitionError
 from ..utils import get_root_joint_dim
 from .task import Task
 
@@ -47,7 +47,12 @@ class JointVelocityTask(Task):
         Args:
             target_v: Target joint-velocity vector in the tangent space.
         """
-        self.__target_Delta_q = target_v.copy()
+        if target_v.ndim != 1:
+            raise TaskDefinitionError(
+                "joint velocity target should be a vector, "
+                f"but the provided target has shape {target_v.shape}"
+            )
+        self.__target_Delta_q = target_v * dt
 
     def compute_error(self, configuration: Configuration) -> np.ndarray:
         r"""Compute the joint-velocity task error.

--- a/pink/tasks/joint_velocity_task.py
+++ b/pink/tasks/joint_velocity_task.py
@@ -36,8 +36,8 @@ class JointVelocityTask(Task):
         """
         super().__init__(
             cost=cost,
-            gain=0.0,  # no gain: the task error is directly a velocity
-            lm_damping=0.0,  # no LM damping either
+            gain=1.0,  # unit gain as the task error is directly a velocity
+            lm_damping=0.0,  # no Levenberg-Marquardt damping
         )
         self.__target_Delta_q = None
 

--- a/pink/tasks/relative_frame_task.py
+++ b/pink/tasks/relative_frame_task.py
@@ -91,12 +91,12 @@ class RelativeFrameTask(Task):
             if not isinstance(position_cost, np.ndarray):  # Must be seq
                 try:
                     position_cost = np.array(position_cost)
-                except Exception:  # Not a proper float sequence
+                except Exception as exn:  # Not a proper float sequence
                     raise TaskDefinitionError(
                         "Position task cost should be a float or a "
                         "seq of float or ndarray of size 1 or 3,"
                         f"currently cost={self.cost}"
-                    )
+                    ) from exn
             assert np.all(position_cost >= 0.0)
 
         self.cost[0:3] = position_cost
@@ -118,12 +118,12 @@ class RelativeFrameTask(Task):
             if not isinstance(orientation_cost, np.ndarray):  # Must be seq
                 try:
                     orientation_cost = np.array(orientation_cost)
-                except Exception:  # Not a proper float sequence
+                except Exception as exn:  # Not a proper float sequence
                     raise TaskDefinitionError(
                         "Orientation task cost should be a float or a "
                         "seq of float or ndarray of size 1 or 3,"
                         f"currently cost={self.cost}"
-                    )
+                    ) from exn
             assert np.all(orientation_cost >= 0.0)
 
         self.cost[3:] = orientation_cost

--- a/pink/tasks/task.py
+++ b/pink/tasks/task.py
@@ -123,8 +123,8 @@ class Task(abc.ABC):
 
         .. math::
 
-            \| J \Delta q + \alpha e \|_{W}^2 = \frac{1}{2} \Delta q^T H
-            \Delta q + c^T q
+            \frac{1}{2} \| J \Delta q + \alpha e \|_{W}^2 = \frac{1}{2} \Delta
+            q^T H \Delta q + c^T q
 
         The weight matrix :math:`W \in \mathbb{R}^{k \times k}` weighs and
         normalizes task coordinates to the same unit. The unit of the overall

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,17 +47,25 @@ line-length = 79
 disable = ["C0103", "E1130", "import-error"]
 generated-members = [
     "pin.Data",
+    "pin.GeometryData",
+    "pin.GeometryModel",
+    "pin.Jlog6",
     "pin.JointModelFreeFlyer",
     "pin.Model",
     "pin.ReferenceFrame",
     "pin.SE3",
+    "pin.centerOfMass",
+    "pin.computeCollisions",
+    "pin.computeDistances",
     "pin.computeJointJacobians",
+    "pin.dDifference",
     "pin.difference",
     "pin.getFrameJacobian",
+    "pin.getJointJacobian",
     "pin.integrate",
     "pin.neutral",
+    "pin.skew",
     "pin.updateFramePlacements",
-    "pin.Jlog6"
 ]
 
 [tool.flit.module]

--- a/tests/test_joint_velocity_task.py
+++ b/tests/test_joint_velocity_task.py
@@ -61,3 +61,17 @@ class TestJointVelocityTask(unittest.TestCase):
         e = task.compute_error(self.configuration)
         J = task.compute_jacobian(self.configuration)
         self.assertEqual(e.shape[0], J.shape[0])
+
+    def test_dt(self):
+        """Check the shapes of the error vector and Jacobian matrix."""
+        task = JointVelocityTask(cost=1.0)
+
+        dt_1 = 3e-3  # seconds
+        task.set_target(np.ones(self.nv - 6), dt_1)
+        e_1 = task.compute_error(self.configuration)
+        self.assertAlmostEqual(e_1[0], dt_1)  # unit target
+
+        dt_2 = 7e-3  # seconds
+        task.set_target(np.ones(self.nv - 6), dt_2)
+        e_2 = task.compute_error(self.configuration)
+        self.assertAlmostEqual(e_2[0], dt_2)  # unit target

--- a/tests/test_joint_velocity_task.py
+++ b/tests/test_joint_velocity_task.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test fixture for the joint velocity task."""
+
+import unittest
+
+import numpy as np
+import pinocchio as pin
+from robot_descriptions.loaders.pinocchio import load_robot_description
+
+from pink import Configuration
+from pink.tasks import JointVelocityTask
+
+
+class TestJointVelocityTask(unittest.TestCase):
+    """Test consistency of the joint velocity task.
+
+    Note:
+        This fixture only tests the task itself. Integration tests with the IK
+        are carried out in :class:`TestSolveIK`.
+    """
+
+    def setUp(self):
+        """Prepare test fixture."""
+        robot = load_robot_description(
+            "ur3_description",
+            root_joint=pin.JointModelFreeFlyer(),
+        )
+        self.configuration = Configuration(robot.model, robot.data, robot.q0)
+
+    def test_task_repr(self):
+        """String representation reports the task gain, costs and target."""
+        task = JointVelocityTask(cost=1.0)
+        self.assertTrue("cost=" in repr(task))
+        self.assertTrue("gain=" in repr(task))
+
+    def test_unit_cost_qp_objective(self):
+        """A unit cost vector means the QP objective is (J^T J, -e^T J)."""
+        task = JointVelocityTask(cost=1.0)
+        e = task.compute_error(self.configuration)
+        J = task.compute_jacobian(self.configuration)
+        H, c = task.compute_qp_objective(self.configuration)
+        self.assertTrue(np.allclose(J.T @ J, H))
+        self.assertTrue(np.allclose(-e.T @ J, c))


### PR DESCRIPTION
This PR adds a `JointVelocityTask` following the discussion in https://github.com/stephane-caron/pink/discussions/146

An example illustrates tracking an unfeasible reference trajectory of joint velocities on a Z1 robotic arm. The reference is tracked as long as it doesn't get the robot outside its joint limits, enforced by the default limits in [`solve_ik`](https://stephane-caron.github.io/pink/inverse-kinematics.html#pink.solve_ik.solve_ik):

https://github.com/user-attachments/assets/3c0e221b-4180-4c8c-9ced-1cc61448c2ad

(In this example, joint limits don't prevent a self-collision when the arm is folded on itself.)