### PR TITLE
Transfer copyright notices to `NOTICE` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Transfer copyright notices to `NOTICE` file
+
 ## [4.2.0] - 2026-04-20
 
 ### Added

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,9 @@
+This project includes contributions made under the following copyrights:
+
+- Copyright 2022 Stéphane Caron
+- Copyright 2023 Inria
+- Copyright 2024 Inria
+- Copyright 2024 Ivan Domrachev, Simeon Nedelchev
+- Copyright 2025 Inria
+- Copyright 2026 CNRS
+- Copyright 2026 Stéphane Caron

--- a/NOTICE
+++ b/NOTICE
@@ -1,9 +1,7 @@
 This project includes contributions made under the following copyrights:
 
 - Copyright 2022 Stéphane Caron
-- Copyright 2023 Inria
-- Copyright 2024 Inria
+- Copyright 2023-2025 Inria
 - Copyright 2024 Ivan Domrachev, Simeon Nedelchev
-- Copyright 2025 Inria
-- Copyright 2026 CNRS
 - Copyright 2026 Stéphane Caron
+- Copyright 2026 CNRS

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 import re
 import sys

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -38,7 +38,7 @@ templates_path = []
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = {'.rst': 'restructuredtext'}
+source_suffix = {".rst": "restructuredtext"}
 
 # The encoding of source files.
 #

--- a/examples/arm_kinova_gen2.py
+++ b/examples/arm_kinova_gen2.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "pin-pink", "meshcat",

--- a/examples/arm_kinova_gen2.py
+++ b/examples/arm_kinova_gen2.py
@@ -10,12 +10,12 @@
 
 """Kinova Gen2 arm tracking a moving target."""
 
+import meshcat_shapes
 import numpy as np
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask

--- a/examples/arm_ur3.py
+++ b/examples/arm_ur3.py
@@ -10,12 +10,12 @@
 
 """Universal Robots UR3 arm tracking a moving target."""
 
+import meshcat_shapes
 import numpy as np
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask

--- a/examples/arm_ur3.py
+++ b/examples/arm_ur3.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/arm_ur3_velocity_smoothing.py
+++ b/examples/arm_ur3_velocity_smoothing.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/arm_ur3_velocity_smoothing.py
+++ b/examples/arm_ur3_velocity_smoothing.py
@@ -11,12 +11,12 @@
 """UR3 arm tracking a target, first without then with velocity smoothing."""
 
 import matplotlib.pyplot as plt
+import meshcat_shapes
 import numpy as np
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.limits import AccelerationLimit

--- a/examples/arm_ur5.py
+++ b/examples/arm_ur5.py
@@ -10,12 +10,12 @@
 
 """Universal Robots UR5 arm tracking a moving target."""
 
+import meshcat_shapes
 import numpy as np
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask

--- a/examples/arm_ur5.py
+++ b/examples/arm_ur5.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/barriers/arm_ur5.py
+++ b/examples/barriers/arm_ur5.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/barriers/arm_ur5.py
+++ b/examples/barriers/arm_ur5.py
@@ -12,12 +12,12 @@
 
 import argparse
 
+import meshcat_shapes
 import numpy as np
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.barriers import PositionBarrier

--- a/examples/barriers/go2_squat.py
+++ b/examples/barriers/go2_squat.py
@@ -10,13 +10,13 @@
 
 """Go2 squat with z-axis barrier."""
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.barriers import PositionBarrier

--- a/examples/barriers/go2_squat.py
+++ b/examples/barriers/go2_squat.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/barriers/kukas_self_collision.py
+++ b/examples/barriers/kukas_self_collision.py
@@ -12,13 +12,13 @@
 
 import os
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.iiwa14_description import PACKAGE_PATH, REPOSITORY_PATH
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.barriers import SelfCollisionBarrier

--- a/examples/barriers/kukas_self_collision.py
+++ b/examples/barriers/kukas_self_collision.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/barriers/meshcat_shapes.py
+++ b/examples/barriers/meshcat_shapes.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["daqp", "meshcat", "pin-pink", "qpsolvers",

--- a/examples/barriers/yumi_self_collision.py
+++ b/examples/barriers/yumi_self_collision.py
@@ -11,13 +11,13 @@
 """Yumi two-armed manipulator with definition of custom frame and
 collision avoidance w.r.t. those frames."""
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.barriers import BodySphericalBarrier

--- a/examples/barriers/yumi_self_collision.py
+++ b/examples/barriers/yumi_self_collision.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/double_pendulum.py
+++ b/examples/double_pendulum.py
@@ -12,12 +12,12 @@
 
 import os
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask

--- a/examples/double_pendulum.py
+++ b/examples/double_pendulum.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/flying_dual_arm_ur3.py
+++ b/examples/flying_dual_arm_ur3.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Inria
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/flying_dual_arm_ur3.py
+++ b/examples/flying_dual_arm_ur3.py
@@ -13,13 +13,13 @@
 from typing import Tuple
 
 import hppfcl as fcl
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask

--- a/examples/humanoid_draco3.py
+++ b/examples/humanoid_draco3.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Inria
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/humanoid_draco3.py
+++ b/examples/humanoid_draco3.py
@@ -10,13 +10,13 @@
 
 """DRACO 3 humanoid standing on two feet and reaching with a hand."""
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, JointCouplingTask, PostureTask

--- a/examples/humanoid_g1_com.py
+++ b/examples/humanoid_g1_com.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/humanoid_jvrc.py
+++ b/examples/humanoid_jvrc.py
@@ -10,13 +10,13 @@
 
 """JVRC-1 humanoid standing on two feet and reaching with a hand."""
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask

--- a/examples/humanoid_jvrc.py
+++ b/examples/humanoid_jvrc.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["clarabel", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/humanoid_sigmaban.py
+++ b/examples/humanoid_sigmaban.py
@@ -10,13 +10,13 @@
 
 """SigmaBan humanoid standing on two feet."""
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask

--- a/examples/humanoid_sigmaban.py
+++ b/examples/humanoid_sigmaban.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Inria
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/load_custom_urdf.py
+++ b/examples/load_custom_urdf.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["pin-pink", "pyglet<2", "yourdfpy"]

--- a/examples/meshcat_shapes.py
+++ b/examples/meshcat_shapes.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["meshcat"]

--- a/examples/mobile_omni_wheeled_robot.py
+++ b/examples/mobile_omni_wheeled_robot.py
@@ -15,12 +15,12 @@ Illustrates the notion of screw path.
 
 import os
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask

--- a/examples/mobile_omni_wheeled_robot.py
+++ b/examples/mobile_omni_wheeled_robot.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/mobile_stretch.py
+++ b/examples/mobile_stretch.py
@@ -10,13 +10,13 @@
 
 """Move a Stretch RE1 with a fixed fingertip target around the origin."""
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import PinkError, solve_ik
 from pink.tasks import FrameTask

--- a/examples/mobile_stretch.py
+++ b/examples/mobile_stretch.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 #
 # /// script
 # dependencies = ["clarabel", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/one_dof_configuration_limit.py
+++ b/examples/one_dof_configuration_limit.py
@@ -29,12 +29,12 @@ to goal tip" distance, and make the pendulum turn anti-clockwise.
 
 import os
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask

--- a/examples/one_dof_configuration_limit.py
+++ b/examples/one_dof_configuration_limit.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2024 Inria
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/robots/omnidirectional_wheeled_robot.urdf
+++ b/examples/robots/omnidirectional_wheeled_robot.urdf
@@ -1,21 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-
-Copyright 2022 Stéphane Caron
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
--->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <robot name="omnidirectional_wheeled">
 
     <material name="light_gray">

--- a/examples/stretch_relative_target.py
+++ b/examples/stretch_relative_target.py
@@ -10,13 +10,13 @@
 
 """Move a Stretch RE1 with a fingertip target in the mobile-base frame."""
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import PinkError, solve_ik
 from pink.tasks import FrameTask, RelativeFrameTask

--- a/examples/stretch_relative_target.py
+++ b/examples/stretch_relative_target.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 #
 # /// script
 # dependencies = ["clarabel", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/stretch_world_target.py
+++ b/examples/stretch_world_target.py
@@ -10,13 +10,13 @@
 
 """Move a Stretch RE1 with a fixed fingertip target around the origin."""
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import PinkError, solve_ik
 from pink.tasks import FrameTask

--- a/examples/stretch_world_target.py
+++ b/examples/stretch_world_target.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 #
 # /// script
 # dependencies = ["clarabel", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/upkie_crouching.py
+++ b/examples/upkie_crouching.py
@@ -10,12 +10,12 @@
 
 """Upkie wheeled biped bending its knees."""
 
+import meshcat_shapes
 import numpy as np
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask

--- a/examples/upkie_crouching.py
+++ b/examples/upkie_crouching.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/upkie_rolling.py
+++ b/examples/upkie_rolling.py
@@ -2,20 +2,19 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 #
 # /// script
 # dependencies = ["clarabel", "loop-rate-limiters", "meshcat", "pin-pink",
 # "qpsolvers", "robot_descriptions"]
 # ///
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, RollingTask

--- a/examples/visualize_in_meshcat.py
+++ b/examples/visualize_in_meshcat.py
@@ -10,13 +10,13 @@
 
 """Upkie wheeled biped bending its knees."""
 
+import meshcat_shapes
 import numpy as np
 import pinocchio as pin
 import qpsolvers
 from loop_rate_limiters import RateLimiter
 from robot_descriptions.loaders.pinocchio import load_robot_description
 
-import meshcat_shapes
 import pink
 from pink import solve_ik
 from pink.tasks import FrameTask, PostureTask

--- a/examples/visualize_in_meshcat.py
+++ b/examples/visualize_in_meshcat.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "meshcat", "pin-pink",

--- a/examples/visualize_in_yourdfpy.py
+++ b/examples/visualize_in_yourdfpy.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 #
 # /// script
 # dependencies = ["daqp", "loop-rate-limiters", "pin-pink", "qpsolvers",

--- a/examples/visualize_in_yourdfpy.py
+++ b/examples/visualize_in_yourdfpy.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
 
     def callback(scene, dz=0.05):
         """Callback function for the visualizer."""
-        global animation_time, configuration
+        global animation_time
         dt = rate.period
 
         # Update task targets

--- a/pink/__init__.py
+++ b/pink/__init__.py
@@ -2,9 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2024 Inria
-# Copyright 2026 CNRS
 
 """Inverse kinematics for articulated robot models, based on Pinocchio."""
 

--- a/pink/barriers/__init__.py
+++ b/pink/barriers/__init__.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 
 """Control Barrier Functions."""
 

--- a/pink/barriers/barrier.py
+++ b/pink/barriers/barrier.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 
 """All barriers derive from the :class:`Barrier` base class.
 

--- a/pink/barriers/body_spherical_barrier.py
+++ b/pink/barriers/body_spherical_barrier.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 
 """Barrier based on the distance between two frames."""
 

--- a/pink/barriers/position_barrier.py
+++ b/pink/barriers/position_barrier.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 
 """Frame position barrier."""
 

--- a/pink/barriers/self_collision_barrier.py
+++ b/pink/barriers/self_collision_barrier.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 
 """Self Collision Avoidance Barrier with hpp-fcl."""
 

--- a/pink/configuration.py
+++ b/pink/configuration.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Configuration of a robot model.
 

--- a/pink/exceptions.py
+++ b/pink/exceptions.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2024 Inria
 
 """Exceptions specific to Pink."""
 

--- a/pink/limits/__init__.py
+++ b/pink/limits/__init__.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Inria
 
 r"""Limits implemented as inequality constraints in the IK problem.
 

--- a/pink/limits/acceleration_limit.py
+++ b/pink/limits/acceleration_limit.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """Subset of acceleration-limited joints in a robot model."""
 

--- a/pink/limits/configuration_limit.py
+++ b/pink/limits/configuration_limit.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 
 """Subset of bounded joints associated with a robot model."""
 

--- a/pink/limits/limit.py
+++ b/pink/limits/limit.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Inria
 
 """All kinematic limits derive from the :class:`Limit` base class."""
 

--- a/pink/limits/velocity_limit.py
+++ b/pink/limits/velocity_limit.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 
 """Subset of velocity-limited joints in a robot model."""
 

--- a/pink/solve_ik.py
+++ b/pink/solve_ik.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Build and solve the inverse kinematics problem."""
 

--- a/pink/tasks/__init__.py
+++ b/pink/tasks/__init__.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Kinematic tasks."""
 

--- a/pink/tasks/com_task.py
+++ b/pink/tasks/com_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Stéphane Caron, Simeon Nedelchev, Ivan Domrachev
 
 """Center of mass task implementation."""
 

--- a/pink/tasks/damping_task.py
+++ b/pink/tasks/damping_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Inria
 
 """Damping task."""
 

--- a/pink/tasks/frame_task.py
+++ b/pink/tasks/frame_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Frame task implementation."""
 

--- a/pink/tasks/joint_coupling_task.py
+++ b/pink/tasks/joint_coupling_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Joint coupling task implementation."""
 

--- a/pink/tasks/joint_velocity_task.py
+++ b/pink/tasks/joint_velocity_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2023 Inria
 
 """Joint velocity task."""
 

--- a/pink/tasks/linear_holonomic_task.py
+++ b/pink/tasks/linear_holonomic_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 r"""Linear holonomic task :math:`A (q \ominus q_0) = b`."""
 

--- a/pink/tasks/low_acceleration_task.py
+++ b/pink/tasks/low_acceleration_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Low acceleration task."""
 

--- a/pink/tasks/omniwheel_task.py
+++ b/pink/tasks/omniwheel_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """Omniwheel task implementation."""
 

--- a/pink/tasks/posture_task.py
+++ b/pink/tasks/posture_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Posture task implementation."""
 

--- a/pink/tasks/relative_frame_task.py
+++ b/pink/tasks/relative_frame_task.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2024 Inria
 
 """Relative frame task implementation."""
 

--- a/pink/tasks/rolling_task.py
+++ b/pink/tasks/rolling_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """Rolling task implementation."""
 

--- a/pink/tasks/task.py
+++ b/pink/tasks/task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """In Pink, all kinematic tasks derive from the :class:`Task` base class.
 

--- a/pink/utils.py
+++ b/pink/utils.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Utility classes and functions."""
 

--- a/pink/visualization.py
+++ b/pink/visualization.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Visualization helpers."""
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,5 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """This file makes sure Python treats the test directory as a package."""

--- a/tests/test_acceleration_limit.py
+++ b/tests/test_acceleration_limit.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """Test acceleration limit."""
 

--- a/tests/test_barrier.py
+++ b/tests/test_barrier.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Tests that should pass for all barriers."""
 

--- a/tests/test_body_spherical_barrier.py
+++ b/tests/test_body_spherical_barrier.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 
 """Tests for position barrier limit."""
 

--- a/tests/test_com_task.py
+++ b/tests/test_com_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Domrachev Ivan, Simeon Nedelchev
 
 """Test fixture for the com task."""
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Test the configuration type."""
 

--- a/tests/test_configuration_limit.py
+++ b/tests/test_configuration_limit.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Test configuration limit."""
 

--- a/tests/test_damping_task.py
+++ b/tests/test_damping_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """Test fixture for the damping task."""
 

--- a/tests/test_frame_task.py
+++ b/tests/test_frame_task.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2024 Inria
 
 """Test fixture for the frame task."""
 

--- a/tests/test_jacobians.py
+++ b/tests/test_jacobians.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2024 Inria
 
 """Test task Jacobian matrices against finite differences."""
 

--- a/tests/test_joint_coupling_task.py
+++ b/tests/test_joint_coupling_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Test fixture for the joint coupling task."""
 

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Tests that should pass for all limits."""
 

--- a/tests/test_linear_holonomic_task.py
+++ b/tests/test_linear_holonomic_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Test fixture for the linear holonomic task."""
 

--- a/tests/test_low_acceleration_task.py
+++ b/tests/test_low_acceleration_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """Test fixture for the low-acceleration task."""
 

--- a/tests/test_omniwheel_task.py
+++ b/tests/test_omniwheel_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """Test fixture for the omniwheel task."""
 

--- a/tests/test_position_barrier.py
+++ b/tests/test_position_barrier.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Tests for position barrier limit."""
 

--- a/tests/test_posture_task.py
+++ b/tests/test_posture_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Test fixture for the posture task."""
 

--- a/tests/test_relative_frame_task.py
+++ b/tests/test_relative_frame_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Inria
 
 """Test fixture for the relative frame task."""
 

--- a/tests/test_rolling_task.py
+++ b/tests/test_rolling_task.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2025 Inria
 
 """Test fixture for the rolling task."""
 

--- a/tests/test_self_collision_barrier.py
+++ b/tests/test_self_collision_barrier.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2024 Ivan Domrachev, Simeon Nedelchev
 
 """Tests for position barrier limit."""
 

--- a/tests/test_solve_ik.py
+++ b/tests/test_solve_ik.py
@@ -473,7 +473,8 @@ class TestSolveIK(unittest.TestCase):
         def test(self):
             if solver in JAX_SOLVERS and not NUMPY_SUPPORTS_COPY_KEYWORD:
                 self.skipTest(
-                    "NumPy copy keyword unsupported, skipping JAX-based solver."
+                    "NumPy copy keyword unsupported, "
+                    "skipping JAX-based solver."
                 )
             configuration, tasks, dt = self.get_jvrc_problem()
             solve_ik(

--- a/tests/test_solve_ik.py
+++ b/tests/test_solve_ik.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Test inverse kinematics."""
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
-# Copyright 2023 Inria
 
 """Test fixture for other library features."""
 

--- a/tests/test_velocity_limit.py
+++ b/tests/test_velocity_limit.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: Apache-2.0
-# Copyright 2022 Stéphane Caron
 
 """Test velocity limit."""
 


### PR DESCRIPTION
This transfer keeps the information preserved while eliminating per-file clutter, reducing merge conflicts, and making attribution easier to maintain and review in one place.

The `NOTICE` file is described in section 4.4 of the Apache-2.0 license. See the how-to guide [Assembling LICENSE and NOTICE files](https://infra.apache.org/licensing-howto.html).