### PR TITLE
Release v4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.0] - 2026-07-15
+
 ### Added
 
 - CICD: Regression test on shortnames of continuous joints
@@ -16,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add `xacrodoc` to project dependencies, required by the official UR robot descriptions
+- Add `xacrodoc` to project dependencies
 - CICD: Switch UR3, UR5 and UR10 to their official descriptions
 - Transfer copyright notices to `NOTICE` file
 - examples: Switch UR3, UR5 and UR10 to their official descriptions
@@ -25,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `typing_extensions` to project dependencies
 - Limit: Fix `AccelerationLimit` braking-distance term for joints without a configuration limit, such as continuous joints
-- Task: Fix `ManipulabilityTask` rejecting continuous (axis-aligned unbounded revolute) joints
+- Task: Update list of revolute-joint shortnames supported by the `ManipulabilityTask`
 
 ## [4.2.0] - 2026-04-20
 
@@ -476,7 +478,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Python package infrastructure
 
-[unreleased]: https://github.com/stephane-caron/pink/compare/v4.2.0...HEAD
+[unreleased]: https://github.com/stephane-caron/pink/compare/v4.3.0...HEAD
+[4.3.0]: https://github.com/stephane-caron/pink/releases/tag/v4.3.0
 [4.2.0]: https://github.com/stephane-caron/pink/releases/tag/v4.2.0
 [4.1.0]: https://github.com/stephane-caron/pink/releases/tag/v4.1.0
 [4.0.0]: https://github.com/stephane-caron/pink/releases/tag/v4.0.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "Pink: Python inverse kinematics based on Pinocchio"
-version: 4.2.0
-date-released: 2026-03-11
+version: 4.3.0
+date-released: 2026-07-15
 url: "https://github.com/stephane-caron/pink"
 license: "Apache-2.0"
 authors:

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ If you use Pink in your scientific works, please cite it *e.g.* as follows:
   author = {Caron, Stéphane and De Mont-Marin, Yann and Budhiraja, Rohan and Bang, Seung Hyeon and Domrachev, Ivan and Nedelchev, Simeon and Du, Peter and Escande, Adrien and Vaillant, Joris and Wingo, Bruce and Patapati, Santosh and San José Pro, Daniel and Marticorena Vidal, Nicolas Guillermo},
   license = {Apache-2.0},
   url = {https://github.com/stephane-caron/pink},
-  version = {4.2.0},
+  version = {4.3.0},
   year = {2026}
 }
 ```

--- a/pink/__init__.py
+++ b/pink/__init__.py
@@ -18,7 +18,7 @@ from .tasks import (
 )
 from .utils import custom_configuration_vector
 
-__version__ = "4.2.0"
+__version__ = "4.3.0"
 
 __all__ = [
     "Configuration",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,21 @@ Source = "https://github.com/stephane-caron/pink"
 Tracker = "https://github.com/stephane-caron/pink/issues"
 Changelog = "https://github.com/stephane-caron/pink/blob/main/CHANGELOG.md"
 
+[tool.flit.module]
+name = "pink"
+
+[tool.flit.sdist]
+exclude = [
+    ".git*",
+    "CITATION.cff",
+    "CONTRIBUTING.md",
+    "doc/",
+    "examples/",
+    "pixi.lock",
+    "tests/",
+    "uv.lock",
+]
+
 [tool.pylint]
 disable = [
     "C0103",  # Variable name doesn't conform to snake_case naming style
@@ -77,9 +92,6 @@ generated-members = [
     "pin.removeCollisionPairs",
     "pin.updateFramePlacements",
 ]
-
-[tool.flit.module]
-name = "pink"
 
 [tool.pixi.workspace]
 channels = ["conda-forge"]


### PR DESCRIPTION
This release fixes a braking-distance bug in the `AccelerationLimit` and updates the list of revolute-joint shortnames supported by the `ManipulabilityTask`. It also adds Python 3.13 and 3.14 to the list of supported versions.

### Added

- CICD: Regression test on shortnames of continuous joints
- Support for Python 3.13
- Support for Python 3.14
- examples: Add an example with the JVRC-1 humanoid backbending via a CoM task

### Changed

- Add `xacrodoc` to project dependencies
- CICD: Switch UR3, UR5 and UR10 to their official descriptions
- Transfer copyright notices to `NOTICE` file
- examples: Switch UR3, UR5 and UR10 to their official descriptions

### Fixed

- Add `typing_extensions` to project dependencies
- Limit: Fix `AccelerationLimit` braking-distance term for joints without a configuration limit, such as continuous joints
- Task: Update list of revolute-joint shortnames supported by the `ManipulabilityTask`